### PR TITLE
fix: ensure milestone assignees are provided on creation

### DIFF
--- a/internal/mcp/milestone/tools.go
+++ b/internal/mcp/milestone/tools.go
@@ -176,7 +176,7 @@ func registerTools(mcpServer *server.MCPServer, configResources *config.Resource
 			),
 			mcp.WithObject("assignees",
 				mcp.Required(),
-				mcp.Description("A list of assignees for the milestone."),
+				mcp.Description("A list of assignees for the milestone. At least one assignee must be provided."),
 				mcp.Properties(map[string]any{
 					"user-ids": map[string]any{
 						"type":        "array",
@@ -236,6 +236,9 @@ func registerTools(mcpServer *server.MCPServer, configResources *config.Resource
 			)
 			if err != nil {
 				return nil, fmt.Errorf("invalid assignees: %w", err)
+			}
+			if milestone.Assignees.IsEmpty() {
+				return nil, fmt.Errorf("at least one assignee must be provided")
 			}
 
 			if err := configResources.TeamworkEngine.Do(ctx, &milestone); err != nil {

--- a/internal/teamwork/types.go
+++ b/internal/teamwork/types.go
@@ -97,6 +97,11 @@ func (m *LegacyUserGroups) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// IsEmpty checks if the LegacyUserGroups contains no IDs.
+func (m LegacyUserGroups) IsEmpty() bool {
+	return len(m.UserIDs) == 0 && len(m.CompanyIDs) == 0 && len(m.TeamIDs) == 0
+}
+
 // Date is a type alias for time.Time, used to represent date values in the API.
 type Date time.Time
 


### PR DESCRIPTION
The assignees are required when creating a milestone and must be enforced during creation.

## Related Issue

None.

## Checklist

- [x] I have read the [contributing guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../blob/main/SECURITY.md).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [cadastros@rafael.net.br](mailto:cadastros@rafael.net.br)) from the maintainers to push the changes.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

None.