### PR TITLE
enh: add resource web links

### DIFF
--- a/internal/teamwork/company/company.go
+++ b/internal/teamwork/company/company.go
@@ -46,6 +46,16 @@ type Company struct {
 	CreatedAt *time.Time `json:"createdAt"`
 	UpdatedAt *time.Time `json:"updatedAt"`
 	Status    string     `json:"status"`
+	WebLink   *string    `json:"webLink,omitempty"`
+}
+
+// PopulateResourceWebLink sets the website URL for the specific resource. It
+// should be called after the object is loaded (the ID is set).
+func (c *Company) PopulateResourceWebLink(server string) {
+	if c.ID == 0 {
+		return
+	}
+	c.WebLink = teamwork.Ref(fmt.Sprintf("https://%s/app/clients/%d", server, c.ID))
 }
 
 // Single represents a request to retrieve a single company by its ID.
@@ -74,6 +84,12 @@ func (s *Single) UnmarshalJSON(data []byte) error {
 	}
 	*s = Single(raw.Company)
 	return nil
+}
+
+// PopulateResourceWebLink sets the website URL for the specific resource. It
+// should be called after the object is loaded (the ID is set).
+func (s *Single) PopulateResourceWebLink(server string) {
+	(*Company)(s).PopulateResourceWebLink(server)
 }
 
 // Multiple represents a request to retrieve multiple companies.
@@ -133,6 +149,14 @@ func (m Multiple) HTTPRequest(ctx context.Context, server string) (*http.Request
 // UnmarshalJSON decodes the JSON data into a Multiple instance.
 func (m *Multiple) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &m.Response)
+}
+
+// PopulateResourceWebLink sets the website URL for the specific resource. It
+// should be called after the object is loaded (the ID is set).
+func (m *Multiple) PopulateResourceWebLink(server string) {
+	for i := range m.Response.Companies {
+		m.Response.Companies[i].PopulateResourceWebLink(server)
+	}
 }
 
 // Create represents the payload for creating a new company in Teamwork.com.

--- a/internal/teamwork/engine.go
+++ b/internal/teamwork/engine.go
@@ -103,7 +103,12 @@ func (e *Engine) Do(ctx context.Context, entity Entity, optFuncs ...Option) erro
 	switch req.Method {
 	case http.MethodGet:
 		decoder := json.NewDecoder(resp.Body)
-		return decoder.Decode(entity)
+		if err := decoder.Decode(entity); err != nil {
+			return fmt.Errorf("failed to decode response body: %w", err)
+		}
+		if resource, ok := entity.(interface{ PopulateResourceWebLink(server string) }); ok {
+			resource.PopulateResourceWebLink(e.server)
+		}
 	case http.MethodPost:
 		var body map[string]any
 		decoder := json.NewDecoder(resp.Body)

--- a/internal/teamwork/helpers.go
+++ b/internal/teamwork/helpers.go
@@ -1,0 +1,6 @@
+package teamwork
+
+// Ref is a utility function that returns a pointer to the value of type T.
+func Ref[T any](v T) *T {
+	return &v
+}

--- a/internal/teamwork/jobrole/jobrole.go
+++ b/internal/teamwork/jobrole/jobrole.go
@@ -31,6 +31,16 @@ type JobRole struct {
 	DeletedByUserID *int64     `json:"deletedByUser"`
 	DeletedAt       *time.Time `json:"deletedAt"`
 	IsActive        bool       `json:"isActive"`
+	WebLink         *string    `json:"webLink,omitempty"`
+}
+
+// PopulateResourceWebLink sets the website URL for the specific resource. It
+// should be called after the object is loaded (the ID is set).
+func (j *JobRole) PopulateResourceWebLink(server string) {
+	if j.ID == 0 {
+		return
+	}
+	j.WebLink = teamwork.Ref(fmt.Sprintf("https://%s/people/roles", server))
 }
 
 // Single represents a request to retrieve a single job role by its ID.
@@ -59,6 +69,12 @@ func (s *Single) UnmarshalJSON(data []byte) error {
 	}
 	*s = Single(raw.JobRole)
 	return nil
+}
+
+// PopulateResourceWebLink sets the website URL for the specific resource. It
+// should be called after the object is loaded (the ID is set).
+func (s *Single) PopulateResourceWebLink(server string) {
+	(*JobRole)(s).PopulateResourceWebLink(server)
 }
 
 // Multiple represents a request to retrieve multiple job roles.
@@ -107,6 +123,14 @@ func (m Multiple) HTTPRequest(ctx context.Context, server string) (*http.Request
 // UnmarshalJSON decodes the JSON data into a Multiple instance.
 func (m *Multiple) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &m.Response)
+}
+
+// PopulateResourceWebLink sets the website URL for the specific resource. It
+// should be called after the object is loaded (the ID is set).
+func (m *Multiple) PopulateResourceWebLink(server string) {
+	for i := range m.Response.JobRoles {
+		m.Response.JobRoles[i].PopulateResourceWebLink(server)
+	}
 }
 
 // Create represents the payload for creating a new job role in Teamwork.com.

--- a/internal/teamwork/milestone/milestone.go
+++ b/internal/teamwork/milestone/milestone.go
@@ -36,6 +36,16 @@ type Milestone struct {
 	CompletedBy *int64     `json:"completedBy"`
 	Completed   bool       `json:"completed"`
 	Status      string     `json:"status"`
+	WebLink     *string    `json:"webLink,omitempty"`
+}
+
+// PopulateResourceWebLink sets the website URL for the specific resource. It
+// should be called after the object is loaded (the ID is set).
+func (m *Milestone) PopulateResourceWebLink(server string) {
+	if m.ID == 0 {
+		return
+	}
+	m.WebLink = teamwork.Ref(fmt.Sprintf("https://%s/app/milestones/%d", server, m.ID))
 }
 
 // Single represents a request to retrieve a single milestone by its ID.
@@ -64,6 +74,12 @@ func (s *Single) UnmarshalJSON(data []byte) error {
 	}
 	*s = Single(raw.Milestone)
 	return nil
+}
+
+// PopulateResourceWebLink sets the website URL for the specific resource. It
+// should be called after the object is loaded (the ID is set).
+func (s *Single) PopulateResourceWebLink(server string) {
+	(*Milestone)(s).PopulateResourceWebLink(server)
 }
 
 // Multiple represents a request to retrieve multiple milestones.
@@ -133,6 +149,14 @@ func (m Multiple) HTTPRequest(ctx context.Context, server string) (*http.Request
 // UnmarshalJSON decodes the JSON data into a Multiple instance.
 func (m *Multiple) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &m.Response)
+}
+
+// PopulateResourceWebLink sets the website URL for the specific resource. It
+// should be called after the object is loaded (the ID is set).
+func (m *Multiple) PopulateResourceWebLink(server string) {
+	for i := range m.Response.Milestones {
+		m.Response.Milestones[i].PopulateResourceWebLink(server)
+	}
 }
 
 // Create represents the payload for creating a new milestone in Teamwork.com.

--- a/internal/teamwork/project/project.go
+++ b/internal/teamwork/project/project.go
@@ -41,6 +41,16 @@ type Project struct {
 	CompletedBy *int64     `json:"completedBy"`
 	Status      string     `json:"status"`
 	Type        string     `json:"type"`
+	WebLink     *string    `json:"webLink,omitempty"`
+}
+
+// PopulateResourceWebLink sets the website URL for the specific resource. It
+// should be called after the object is loaded (the ID is set).
+func (p *Project) PopulateResourceWebLink(server string) {
+	if p.ID == 0 {
+		return
+	}
+	p.WebLink = teamwork.Ref(fmt.Sprintf("https://%s/app/projects/%d", server, p.ID))
 }
 
 // Single represents a request to retrieve a single project by its ID.
@@ -69,6 +79,12 @@ func (s *Single) UnmarshalJSON(data []byte) error {
 	}
 	*s = Single(raw.Project)
 	return nil
+}
+
+// PopulateResourceWebLink sets the website URL for the specific resource. It
+// should be called after the object is loaded (the ID is set).
+func (s *Single) PopulateResourceWebLink(server string) {
+	(*Project)(s).PopulateResourceWebLink(server)
 }
 
 // Multiple represents a request to retrieve multiple projects.
@@ -128,6 +144,14 @@ func (m Multiple) HTTPRequest(ctx context.Context, server string) (*http.Request
 // UnmarshalJSON decodes the JSON data into a Multiple instance.
 func (m *Multiple) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &m.Response)
+}
+
+// PopulateResourceWebLink sets the website URL for the specific resource. It
+// should be called after the object is loaded (the ID is set).
+func (m *Multiple) PopulateResourceWebLink(server string) {
+	for i := range m.Response.Projects {
+		m.Response.Projects[i].PopulateResourceWebLink(server)
+	}
 }
 
 // Create represents the payload for creating a new project in Teamwork.com.

--- a/internal/teamwork/tag/tag.go
+++ b/internal/teamwork/tag/tag.go
@@ -26,6 +26,17 @@ type Tag struct {
 	Name string `json:"name"`
 
 	Project *teamwork.Relationship `json:"project"`
+
+	WebLink *string `json:"webLink,omitempty"`
+}
+
+// PopulateResourceWebLink sets the website URL for the specific resource. It
+// should be called after the object is loaded (the ID is set).
+func (t *Tag) PopulateResourceWebLink(server string) {
+	if t.ID == 0 {
+		return
+	}
+	t.WebLink = teamwork.Ref(fmt.Sprintf("https://%s/app/settings/tags", server))
 }
 
 // Single represents a request to retrieve a single tag by its ID.
@@ -54,6 +65,12 @@ func (s *Single) UnmarshalJSON(data []byte) error {
 	}
 	*s = Single(raw.Tag)
 	return nil
+}
+
+// PopulateResourceWebLink sets the website URL for the specific resource. It
+// should be called after the object is loaded (the ID is set).
+func (s *Single) PopulateResourceWebLink(server string) {
+	(*Tag)(s).PopulateResourceWebLink(server)
 }
 
 // Multiple represents a request to retrieve multiple tags.
@@ -113,6 +130,14 @@ func (m Multiple) HTTPRequest(ctx context.Context, server string) (*http.Request
 // UnmarshalJSON decodes the JSON data into a Multiple instance.
 func (m *Multiple) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &m.Response)
+}
+
+// PopulateResourceWebLink sets the website URL for the specific resource. It
+// should be called after the object is loaded (the ID is set).
+func (m *Multiple) PopulateResourceWebLink(server string) {
+	for i := range m.Response.Tags {
+		m.Response.Tags[i].PopulateResourceWebLink(server)
+	}
 }
 
 // Create represents the payload for creating a new tag in Teamwork.com.

--- a/internal/teamwork/tasklist/tasklist.go
+++ b/internal/teamwork/tasklist/tasklist.go
@@ -36,6 +36,16 @@ type Tasklist struct {
 	CreatedAt *time.Time `json:"createdAt"`
 	UpdatedAt *time.Time `json:"updatedAt"`
 	Status    string     `json:"status"`
+	WebLink   *string    `json:"webLink,omitempty"`
+}
+
+// PopulateResourceWebLink sets the website URL for the specific resource. It
+// should be called after the object is loaded (the ID is set).
+func (t *Tasklist) PopulateResourceWebLink(server string) {
+	if t.ID == 0 {
+		return
+	}
+	t.WebLink = teamwork.Ref(fmt.Sprintf("https://%s/app/tasklists/%d", server, t.ID))
 }
 
 // Single represents a request to retrieve a single tasklist by its ID.
@@ -64,6 +74,12 @@ func (s *Single) UnmarshalJSON(data []byte) error {
 	}
 	*s = Single(raw.Tasklist)
 	return nil
+}
+
+// PopulateResourceWebLink sets the website URL for the specific resource. It
+// should be called after the object is loaded (the ID is set).
+func (s *Single) PopulateResourceWebLink(server string) {
+	(*Tasklist)(s).PopulateResourceWebLink(server)
 }
 
 // Multiple represents a request to retrieve multiple tasklists.
@@ -122,6 +138,14 @@ func (m Multiple) HTTPRequest(ctx context.Context, server string) (*http.Request
 // UnmarshalJSON decodes the JSON data into a Multiple instance.
 func (m *Multiple) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &m.Response)
+}
+
+// PopulateResourceWebLink sets the website URL for the specific resource. It
+// should be called after the object is loaded (the ID is set).
+func (m *Multiple) PopulateResourceWebLink(server string) {
+	for i := range m.Response.Tasklists {
+		m.Response.Tasklists[i].PopulateResourceWebLink(server)
+	}
 }
 
 // Create represents the payload for creating a new tasklist in Teamwork.com.


### PR DESCRIPTION
Allow retrieving the resource web links to navigate in a web browser.

<img width="1034" alt="image" src="https://github.com/user-attachments/assets/c5b8f53d-727d-48db-bbbf-d090122b6ee9" />

## Related Issue

None.

## Checklist

- [x] I have read the [contributing guidelines](../blob/main/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../blob/main/SECURITY.md).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [cadastros@rafael.net.br](mailto:cadastros@rafael.net.br)) from the maintainers to push the changes.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

None.