### PR TITLE
feat: add assigner service to handle Teamwork.com webhooks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ FROM golang:1.24-alpine AS builder
 
 WORKDIR /usr/src/teamwork-ai
 COPY --chown=root:root . /usr/src/teamwork-ai
-RUN go build -o /app/teamwork-ai-mcp ./cmd/mcp
+RUN go build -o /app/teamwork-ai-mcp ./cmd/mcp && \
+  go build -o /app/teamwork-ai-assigner ./cmd/assigner
 
 
 # ██▀███   █    ██  ███▄    █  ███▄    █ ▓█████  ██▀███  
@@ -35,6 +36,7 @@ ARG BUILD_VCS_REF
 ARG BUILD_VERSION
 
 COPY --from=builder /app/teamwork-ai-mcp /bin/teamwork-ai-mcp
+COPY --from=builder /app/teamwork-ai-assigner /bin/teamwork-ai-assigner
 
 LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Teamwork.com extension for AI" \

--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,9 @@ artifacts:
 	GOOS=linux   GOARCH=arm64 go build -o teamwork-mcp-linux-arm64 ./cmd/mcp
 	GOOS=darwin  GOARCH=amd64 go build -o teamwork-mcp-darwin-amd64 ./cmd/mcp
 	GOOS=darwin  GOARCH=arm64 go build -o teamwork-mcp-darwin-arm64 ./cmd/mcp
+
+	GOOS=windows GOARCH=amd64 go build -o teamwork-assigner-windows-amd64 ./cmd/assigner
+	GOOS=linux   GOARCH=amd64 go build -o teamwork-assigner-linux-amd64 ./cmd/assigner
+	GOOS=linux   GOARCH=arm64 go build -o teamwork-assigner-linux-arm64 ./cmd/assigner
+	GOOS=darwin  GOARCH=amd64 go build -o teamwork-assigner-darwin-amd64 ./cmd/assigner
+	GOOS=darwin  GOARCH=arm64 go build -o teamwork-assigner-darwin-arm64 ./cmd/assigner

--- a/README.md
+++ b/README.md
@@ -43,137 +43,14 @@ tasklist name, the task title and description to find the best match for the
 users' skills.
 ```
 
-### 📦 Installing
+**For more information check [our documentation](cmd/mcp/README.md).**
 
-You can install the MCP server using [`go`](https://go.dev/doc/install):
+## Assigner
 
-```bash
-go install -o teamwork-mcp github.com/rafaeljusto/teamwork-ai/cmd/mcp@latest
-```
+The assigner is a webservice that integrates with Teamwork.com webhooks,
+handling task creation and updates. It behave as an Agentic AI, extracting
+skills and job roles from the task and assigning the best user to fulfill it.
 
-The binary will be installed in your `GOPATH/bin` directory, which is usually
-`$HOME/go/bin`. Make sure to add this directory to your `PATH` environment
-variable to run the `teamwork-mcp` command from anywhere.
+[![Assigner](https://img.youtube.com/vi/syeb50mia_M/0.jpg)](https://www.youtube.com/watch?v=syeb50mia_M)
 
-Alternatively, you can use the pre-built binaries available in the
-[releases](https://github.com/rafaeljusto/teamwork-ai/releases/latest) page.
-Download the appropriate binary for your operating system, extract it, and place
-it in a directory included in your `PATH`. For example, on Linux (amd64) using
-`curl`:
-
-```bash
-# detect the latest release
-twai_mcp_url=$(curl -s https://api.github.com/repos/rafaeljusto/teamwork-ai/releases/latest | \
-  jq '.assets[] | select(.name | contains ("teamwork-mcp-linux-amd64")) | .browser_download_url')
-
-# download the binary and place it in /usr/local/bin
-sudo curl -s -O /usr/local/bin/teamwork-mcp ${twai_mcp_url}
-```
-
-The example above uses `jq` to parse the JSON response from the GitHub API,
-which is a command-line JSON processor. You can find installation instructions
-for it [here](https://jqlang.org/download/).
-
-### ⚡️ Usage
-
-The server works using 2 different modes:
-
-1. **Local mode**: Runs as a local server (`stdio`), allowing AI clients to
-   connect directly. You can, for example, install [Claude
-   Desktop](https://claude.ai/download), which supports MCP, and configure it
-   like:
-
-```json
-{
-  "mcpServers": {
-    "Teamwork AI": {
-      "command": "teamwork-mcp",
-      "args": [
-        "-mode=stdio"
-      ],
-      "env": {
-        "TWAI_TEAMWORK_SERVER": "https://<installation>.teamwork.com",
-        "TWAI_TEAMWORK_API_TOKEN": "<api-token>"
-      }
-    }
-  }
-}
-```
-
-> [!TIP]
-> For more information regarding the Claude Desktop configuration, refer to the
-> [MCP documentation](https://modelcontextprotocol.io/quickstart/user). To
-> further learn about Claude and MCP, you can also check [this
-> content](https://www.claudemcp.com/).
->
-> Be aware of the daily usage limits and how to follow the best practices
-> [here](https://support.anthropic.com/en/articles/9797557-usage-limit-best-practices).
-
-It assumes that [the binary](cmd/mcp/main.go) is compiled and installed in one
-of the directories in your `PATH`. The `<installation>` is the name of your
-Teamwork.com installation, and `<api-token>` is your API token from Teamwork.com
-profile (no support for OAuth2 yet).
-
-> [!IMPORTANT]
-> The API token MUST have enough permissions to execute the desired actions when
-> interacting with the AI client.
-
-2. **Remote mode**: Runs as a remote server (`sse`). This can also be used with
-   [Claude Desktop](https://claude.ai/download) with the following
-   configuration:
-
-```json
-{
-  "mcpServers": {
-    "math": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "https://<server>/sse"
-      ]
-    }
-  }
-}
-```
-
-Where `<server>` is the URL of the remote MCP server.
-
-> [!NOTE]
-> When using Claude Desktop, for every MCP tool execution the AI client will ask
-> for confirmation before executing a tool. This is a safety feature to prevent
-> unintended actions.
-
-### 🔌 Supported entities
-
-Below is a table summarizing the supported entities and their operations in the
-MCP server.
-
-| Entity            | Create | Retrieve | Update | Delete | Extra                                                           |
-|-------------------|--------|----------|--------|--------|-----------------------------------------------------------------|
-| Projects          | ✅     | ✅       | ✅      | ❌     |                                                                 |
-| Tasklists         | ✅     | ✅       | ✅      | ❌     | Retrieve by project                                             |
-| Tasks             | ✅     | ✅       | ✅      | ❌     | Retrieve by project; retrieve by tasklist                       |
-| Companies/Clients | ✅     | ✅       | ✅      | ❌     |                                                                 |
-| Users/People      | ✅     | ✅       | ✅      | ❌     | Retrieve by project; add to a project; assign/unassign job role |
-| Skills            | ✅     | ✅       | ✅      | ❌     |                                                                 |
-| Industries        | ❌     | ✅       | ❌      | ❌     |                                                                 |
-| Tags              | ✅     | ✅       | ✅      | ❌     |                                                                 |
-| Milestones        | ✅     | ✅       | ✅      | ❌     | Retrieve by project                                             |
-| Job roles         | ✅     | ✅       | ✅      | ❌     |                                                                 |
-
-> [!NOTE]
-> Not all properties are supported for each entity. And, for now, delete actions
-> are not implemented for safety.
-
-### 🤓 Debug
-
-For debugging purposes, you can run the [MCP Inspector
-tool](https://github.com/modelcontextprotocol/inspector):
-
-```bash
-npx @modelcontextprotocol/inspector node build/index.js
-```
-
-> [!TIP]
-> For more information regarding the MCP Inspector tool and how to use it, check
-> it [here](https://modelcontextprotocol.io/docs/tools/inspector).
+**For more information check [our documentation](cmd/assigner/README.md).**

--- a/cmd/assigner/README.md
+++ b/cmd/assigner/README.md
@@ -1,0 +1,174 @@
+# Assigner
+
+The Assigner works as a webhook server that listens for incoming requests from
+Teamwork.com. The server will analyze the incoming request and assign the tasks
+to the users based on skill, job roles, user costs and workload. The server will
+also generate a comment explaining the assignment.
+
+For the user costs and workload analysis, it will be used a scoring approach.
+Where cheaper and more available users will have a higher score. The top-scoring
+user (or users if scores are equal) will be assigned to the task.
+
+Keep in mind that the workload analysis has bigger weight than the user cost
+analysis. This means that if a user has a high workload, they will be less
+likely to be assigned to the task, even if they are cheaper than other users.
+
+### 📦 Installing
+
+You can install the Assigner server using [`go`](https://go.dev/doc/install):
+
+```bash
+go install -o teamwork-assigner github.com/rafaeljusto/teamwork-ai/cmd/assigner@latest
+```
+
+The binary will be installed in your `GOPATH/bin` directory, which is usually
+`$HOME/go/bin`. Make sure to add this directory to your `PATH` environment
+variable to run the `teamwork-assigner` command from anywhere.
+
+Alternatively, you can use the pre-built binaries available in the
+[releases](https://github.com/rafaeljusto/teamwork-ai/releases/latest) page.
+Download the appropriate binary for your operating system, extract it, and place
+it in a directory included in your `PATH`. For example, on Linux (amd64) using
+`curl`:
+
+```bash
+# detect the latest release
+twai_assigner_url=$(curl -s https://api.github.com/repos/rafaeljusto/teamwork-ai/releases/latest | \
+  jq '.assets[] | select(.name | contains ("teamwork-assigner-linux-amd64")) | .browser_download_url')
+
+# download the binary and place it in /usr/local/bin
+sudo curl -s -O /usr/local/bin/teamwork-assigner ${twai_assigner_url}
+```
+
+The example above uses `jq` to parse the JSON response from the GitHub API,
+which is a command-line JSON processor. You can find installation instructions
+for it [here](https://jqlang.org/download/).
+
+### ⚙️ Configuring
+
+The following environment variables are required to run the Assigner server:
+- `TWAI_TEAMWORK_SERVER`: The URL of your Teamwork.com installation. For
+  example, `https://<installation>.teamwork.com`.
+- `TWAI_TEAMWORK_API_TOKEN`: The API token for your Teamwork.com account. You can
+  generate a new API token in your Teamwork.com profile. For more information,
+  check the [API documentation](https://apidocs.teamwork.com/guides/teamwork/authentication#basic-authentication).
+- `TWAI_AGENTIC_NAME`: The name of the agent that will be used to extract
+  information from the task. The possible values are `anthropic`, `openai` and
+  `ollama`.
+- `TWAI_AGENTIC_DSN`: The connection string for the agentic model. The format of
+  the connection string depends on the agentic name:
+  * `anthropic`: `model:token`. Where `model` is the name of the model (e.g.,
+    `claude-2`) and `token` is the API key for the Anthropic account. All
+    available models can be found [here](https://docs.anthropic.com/en/docs/about-claude/models/all-models).
+  * `openai`: `model:token`. Where `model` is the name of the model (e.g.,
+    `gpt-3.5-turbo`) and `token` is the API key for the OpenAI account. All
+    available models can be found [here](https://platform.openai.com/docs/models).
+  * `ollama`: `http[s]://[username[:password]@]host[:port]/model`. Where
+    `username` and `password` are the credentials for the Ollama account, `host`
+    is the host name or IP address of the Ollama server, and `port` is the port
+    number of the Ollama server. The `model` is the name of the model to use
+    (e.g. `llama2`), all available models can be found
+    [here](https://ollama.com/search).
+
+Other optional environment variables are:
+- `TWAI_PORT`: The port to run the Assigner server. By default it will use a
+  random available port in the machine.
+- `TWAI_LOG_LEVEL`: The log level for the Assigner server. By default it will
+  use `info`. Available log levels are `debug`, `info`, `warn` and `error`.
+
+There are also some optional flags that you can use when running the Assigner
+server:
+- `skip-rates`: Skip user cost analysis when assigning the tasks. By default,
+  the server will analyze the user rates and assign the tasks to the users with
+  the lowest cost. If multiple users have the same cost, the server will assign
+  to all selected users.
+- `skip-workload`: Skip workload analysis when assigning the tasks. By default,
+  the server will analyze the user workload and assign the tasks to the users
+  with the lowest workload. If multiple users have the same workload, the server
+  will assign to all selected users.
+- `skip-assignment`: Skip the assignment of tasks to users. This is useful when
+  you only need a suggestion from the AI as a comment instead of proactively
+  assigning the tasks to users. By default, the server will assign the task.
+- `skip-comment`: Skip the comment generation. This is useful when you only need
+  to assign the tasks to users without any explanation. By default, the server
+  will generate a comment explaining the assignment.
+
+### ⚡️ Usage
+
+After installing and configuring the Assigner server, you will need to run the
+server and register it as a webhook in your Teamwork.com account. All the steps
+to configure the webhook can be found
+[here](https://apidocs.teamwork.com/guides/teamwork/setting-up-webhooks).
+
+The webhhok URL can be associated with `TASK.CREATED` and `TASK.UPDATED` events.
+At the moment there's no token or checksum check implemented in the server and
+only version 2 of Teamwork.com webhooks is supported.
+
+> [!IMPORTANT]
+> Do not forget to add the URL path `/teamwork-ai/webhooks/task` to the webhook
+> URL.
+
+> [!TIP]
+> For testing purposes we recommend using `ngrok` to expose a local running
+> server to the Internet. Follow more information about `ngrok`
+> [here](https://ngrok.com/docs/getting-started/).
+
+### 📜 API
+
+The Assigner server exposes a single endpoint to receive the incoming requests
+from Teamwork.com. The endpoint is `/teamwork-ai/webhooks/task` and it accepts
+`POST` requests. An example of a JSON payload that the server will receive:
+
+```json
+{
+  "eventCreator": {
+    "id": 160342,
+    "firstName": "Rafael",
+    "lastName": "Dantas Justo",
+    "avatar": "https://s3.amazonaws.com/TWFiles/488712/userAvatar/tf_67324674-9202-4b8d-9957-454392c49faa.avatar.gif"
+  },
+  "project": {
+    "id": 581677,
+    "name": "Game Development Project",
+    "description": "A comprehensive project to develop a new game with defined milestones, task lists, and deadlines to ensure completion within 2025.",
+    "status": "active",
+    "startDate": "2025-04-22",
+    "endDate": "2025-12-31",
+    "tags": [],
+    "ownerId": 0,
+    "companyId": 796953,
+    "categoryId": 0,
+    "dateCreated": "2025-04-22T10:55:38Z"
+  },
+  "task": {
+    "id": 16367318,
+    "name": "Write a Go program for the Game menu",
+    "description": "The game needs a menu and it would be important to be written in the Go language.\n",
+    "priority": null,
+    "status": "new",
+    "assignedUserIds": [],
+    "parentId": 0,
+    "taskListId": 1404538,
+    "startDate": null,
+    "dueDate": null,
+    "progress": 0,
+    "estimatedMinutes": 0,
+    "tags": [],
+    "projectId": 581677,
+    "dateCreated": "2025-05-01T17:34:45Z",
+    "dateUpdated": "2025-05-01T17:34:45Z",
+    "hasCustomFields": false
+  },
+  "taskList": {
+    "id": 1404538,
+    "name": "General tasks",
+    "description": "",
+    "status": "new",
+    "milestoneId": 0,
+    "projectId": 581677,
+    "templateId": null,
+    "tags": []
+  },
+  "users": []
+}
+```

--- a/cmd/assigner/main.go
+++ b/cmd/assigner/main.go
@@ -1,0 +1,180 @@
+// Package main is an HTTP server that reacts to Teamwork.com webhooks and
+// assigns users to tasks based on AI and workload decisions.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/rafaeljusto/teamwork-ai/internal/agentic/actions"
+	_ "github.com/rafaeljusto/teamwork-ai/internal/agentic/anthropic"
+	_ "github.com/rafaeljusto/teamwork-ai/internal/agentic/ollama"
+	_ "github.com/rafaeljusto/teamwork-ai/internal/agentic/openai"
+	"github.com/rafaeljusto/teamwork-ai/internal/config"
+	"github.com/rafaeljusto/teamwork-ai/internal/webhook"
+)
+
+var (
+	skipRates      bool
+	skipWorkload   bool
+	skipAssignment bool
+	skipComment    bool
+)
+
+func main() {
+	defer handleExit()
+
+	flag.BoolVar(&skipRates, "skip-rates", false, "Skip rate analysis when assigning a task")
+	flag.BoolVar(&skipWorkload, "skip-workload", false, "Skip workload analysis when assigning a task")
+	flag.BoolVar(&skipAssignment, "skip-assignment", false, "Skip task assignment (only comment)")
+	flag.BoolVar(&skipComment, "skip-comment", false, "Skip task comment (only assign)")
+	flag.Parse()
+
+	c, errs := config.ParseFromEnvs()
+	if errs != nil {
+		// We are using a logger to print the errors because we don't have a
+		// logger yet. We could use the standard logger, but it's better to
+		// create a logger with the correct configuration.
+		logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelError,
+		}))
+		for _, err := range multierr(errs) {
+			logger.Error("failed to parse configuration",
+				slog.String("error", err.Error()),
+			)
+		}
+		exit(exitCodeInvalidInput)
+	}
+	resources := config.NewResources(c)
+
+	listener, err := net.Listen("tcp", ":"+strconv.FormatInt(c.Port, 10))
+	if err != nil {
+		resources.Logger.Error("failed to listen",
+			slog.String("error", err.Error()),
+		)
+		exit(exitCodeSetupFailure)
+	}
+
+	resources.Logger.Info("starting web server",
+		slog.String("address", listener.Addr().String()),
+	)
+
+	router := http.NewServeMux()
+	router.HandleFunc("POST /teamwork-ai/webhooks/task", handleTask(resources))
+
+	server := http.Server{
+		Handler: router,
+	}
+
+	done := make(chan os.Signal, 1)
+	signal.Notify(done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		if err := server.Serve(listener); err != nil {
+			if err != http.ErrServerClosed {
+				resources.Logger.Error("failed to serve",
+					slog.String("error", err.Error()),
+				)
+			}
+		}
+	}()
+
+	<-done
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer func() {
+		cancel()
+	}()
+	if err := server.Shutdown(ctx); err != nil {
+		resources.Logger.Error("server shutdown failed",
+			slog.String("error", err.Error()),
+		)
+	}
+	resources.Logger.Info("server stopped")
+}
+
+func handleTask(resources *config.Resources) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		decoder := json.NewDecoder(r.Body)
+		var taskData webhook.TaskData
+		if err := decoder.Decode(&taskData); err != nil {
+			resources.Logger.Error("failed to decode request body",
+				slog.String("error", err.Error()),
+			)
+			http.Error(w, "failed to decode request body", http.StatusBadRequest)
+			return
+		}
+
+		var options []actions.AutoAssignTaskOption
+		if skipRates {
+			options = append(options, actions.WithAutoAssignTaskSkipRates())
+		}
+		if skipWorkload {
+			options = append(options, actions.WithAutoAssignTaskSkipWorkload())
+		}
+		if skipAssignment {
+			options = append(options, actions.WithAutoAssignTaskSkipAssignment())
+		}
+		if skipComment {
+			options = append(options, actions.WithAutoAssignTaskSkipComment())
+		}
+
+		if err := actions.AutoAssignTask(r.Context(), resources, taskData, options...); err != nil {
+			resources.Logger.Error("failed to auto assign task",
+				slog.String("error", err.Error()),
+			)
+			http.Error(w, "failed to auto assign task", http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+type exitCode int
+
+const (
+	exitCodeOK exitCode = iota
+	exitCodeInvalidInput
+	exitCodeSetupFailure
+)
+
+type exitData struct {
+	code exitCode
+}
+
+// exit allows to abort the program while still executing all defer statements.
+func exit(code exitCode) {
+	panic(exitData{code: code})
+}
+
+// handleExit exit code handler.
+func handleExit() {
+	if e := recover(); e != nil {
+		if exit, ok := e.(exitData); ok {
+			os.Exit(int(exit.code))
+		}
+		panic(e)
+	}
+}
+
+// multierr unwraps multiple errors from a single error.
+//
+// https://pkg.go.dev/errors#Join
+func multierr(errs error) []error {
+	if errs == nil {
+		return nil
+	}
+	if multierr, ok := errs.(interface{ Unwrap() []error }); ok {
+		return multierr.Unwrap()
+	}
+	return []error{errs}
+}

--- a/cmd/mcp/README.md
+++ b/cmd/mcp/README.md
@@ -1,0 +1,162 @@
+# MCP server
+
+Implements the Model Context Protocol (MCP) to allow AI agents to interact with
+Teamwork.com. This server acts as a bridge between AI clients and Teamwork.com,
+adding tools to create tasks, projects, and more.
+
+### 📦 Installing
+
+You can install the MCP server using [`go`](https://go.dev/doc/install):
+
+```bash
+go install -o teamwork-mcp github.com/rafaeljusto/teamwork-ai/cmd/mcp@latest
+```
+
+The binary will be installed in your `GOPATH/bin` directory, which is usually
+`$HOME/go/bin`. Make sure to add this directory to your `PATH` environment
+variable to run the `teamwork-mcp` command from anywhere.
+
+Alternatively, you can use the pre-built binaries available in the
+[releases](https://github.com/rafaeljusto/teamwork-ai/releases/latest) page.
+Download the appropriate binary for your operating system, extract it, and place
+it in a directory included in your `PATH`. For example, on Linux (amd64) using
+`curl`:
+
+```bash
+# detect the latest release
+twai_mcp_url=$(curl -s https://api.github.com/repos/rafaeljusto/teamwork-ai/releases/latest | \
+  jq '.assets[] | select(.name | contains ("teamwork-mcp-linux-amd64")) | .browser_download_url')
+
+# download the binary and place it in /usr/local/bin
+sudo curl -s -O /usr/local/bin/teamwork-mcp ${twai_mcp_url}
+```
+
+The example above uses `jq` to parse the JSON response from the GitHub API,
+which is a command-line JSON processor. You can find installation instructions
+for it [here](https://jqlang.org/download/).
+
+### ⚙️ Configuring
+
+The following environment variables are required to run the MCP server:
+- `TWAI_TEAMWORK_SERVER`: The URL of your Teamwork.com installation. For
+  example, `https://<installation>.teamwork.com`.
+- `TWAI_TEAMWORK_API_TOKEN`: The API token for your Teamwork.com account. You can
+  generate a new API token in your Teamwork.com profile. For more information,
+  check the [API documentation](https://apidocs.teamwork.com/guides/teamwork/authentication#basic-authentication).
+
+Other optional environment variables are:
+- `TWAI_PORT`: The port to run the MCP server. By default it will use a random
+  available port in the machine. This will be used only when using the `sse`
+  mode.
+- `TWAI_LOG_LEVEL`: The log level for the MCP server. By default it will use
+  `info`. Available log levels are `debug`, `info`, `warn` and `error`.
+
+There are also some optional flags that you can use when running the MCP server:
+- `-mode`: The mode to run the MCP server. It can be `stdio` or `sse`. By
+  default it will use `sse`. For more information about the modes, check the
+  [Usage section](#️usage), or the documentation
+  [here](https://modelcontextprotocol.io/docs/concepts/transports#built-in-transport-types).
+
+### ⚡️ Usage
+
+The server works using 2 different modes:
+
+1. **Local mode**: Runs as a local server (`stdio`), allowing AI clients to
+   connect directly. You can, for example, install [Claude
+   Desktop](https://claude.ai/download), which supports MCP, and configure it
+   like:
+
+```json
+{
+  "mcpServers": {
+    "Teamwork AI": {
+      "command": "teamwork-mcp",
+      "args": [
+        "-mode=stdio"
+      ],
+      "env": {
+        "TWAI_TEAMWORK_SERVER": "https://<installation>.teamwork.com",
+        "TWAI_TEAMWORK_API_TOKEN": "<api-token>"
+      }
+    }
+  }
+}
+```
+
+> [!TIP]
+> For more information regarding the Claude Desktop configuration, refer to the
+> [MCP documentation](https://modelcontextprotocol.io/quickstart/user). To
+> further learn about Claude and MCP, you can also check [this
+> content](https://www.claudemcp.com/).
+>
+> Be aware of the daily usage limits and how to follow the best practices
+> [here](https://support.anthropic.com/en/articles/9797557-usage-limit-best-practices).
+
+It assumes that [the binary](main.go) is compiled and installed in one of the
+directories in your `PATH`. The `<installation>` is the name of your
+Teamwork.com installation, and `<api-token>` is your API token from Teamwork.com
+profile (no support for OAuth2 yet).
+
+> [!IMPORTANT]
+> The API token MUST have enough permissions to execute the desired actions when
+> interacting with the AI client.
+
+2. **Remote mode**: Runs as a remote server (`sse`). This can also be used with
+   [Claude Desktop](https://claude.ai/download) with the following
+   configuration:
+
+```json
+{
+  "mcpServers": {
+    "math": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://<server>/sse"
+      ]
+    }
+  }
+}
+```
+
+Where `<server>` is the URL of the remote MCP server.
+
+> [!NOTE]
+> When using Claude Desktop, for every MCP tool execution the AI client will ask
+> for confirmation before executing a tool. This is a safety feature to prevent
+> unintended actions.
+
+### 🔌 Supported entities
+
+Below is a table summarizing the supported entities and their operations in the
+MCP server.
+
+| Entity            | Create | Retrieve | Update | Delete | Extra                                                           |
+|-------------------|--------|----------|--------|--------|-----------------------------------------------------------------|
+| Projects          | ✅     | ✅       | ✅      | ❌     |                                                                 |
+| Tasklists         | ✅     | ✅       | ✅      | ❌     | Retrieve by project                                             |
+| Tasks             | ✅     | ✅       | ✅      | ❌     | Retrieve by project; retrieve by tasklist                       |
+| Companies/Clients | ✅     | ✅       | ✅      | ❌     |                                                                 |
+| Users/People      | ✅     | ✅       | ✅      | ❌     | Retrieve by project; add to a project; assign/unassign job role |
+| Skills            | ✅     | ✅       | ✅      | ❌     |                                                                 |
+| Industries        | ❌     | ✅       | ❌      | ❌     |                                                                 |
+| Tags              | ✅     | ✅       | ✅      | ❌     |                                                                 |
+| Milestones        | ✅     | ✅       | ✅      | ❌     | Retrieve by project                                             |
+| Job roles         | ✅     | ✅       | ✅      | ❌     |                                                                 |
+
+> [!NOTE]
+> Not all properties are supported for each entity. And, for now, delete actions
+> are not implemented for safety.
+
+### 🤓 Debug
+
+For debugging purposes, you can run the [MCP Inspector
+tool](https://github.com/modelcontextprotocol/inspector):
+
+```bash
+npx @modelcontextprotocol/inspector node build/index.js
+```
+
+> [!TIP]
+> For more information regarding the MCP Inspector tool and how to use it, check
+> it [here](https://modelcontextprotocol.io/docs/tools/inspector).

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.2
 require github.com/mark3labs/mcp-go v0.25.0
 
 require (
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/internal/agentic/actions/assigner.go
+++ b/internal/agentic/actions/assigner.go
@@ -1,0 +1,484 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rafaeljusto/teamwork-ai/internal/config"
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork"
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/comment"
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/jobrole"
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/skill"
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/task"
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/user"
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/workload"
+	"github.com/rafaeljusto/teamwork-ai/internal/webhook"
+)
+
+var processing sync.Map
+
+// AutoAssignTaskOptions contains the options for the AutoAssignTask function.
+type AutoAssignTaskOptions struct {
+	skipRates      bool
+	skipWorkload   bool
+	skipAssignment bool
+	skipComment    bool
+}
+
+// AutoAssignTaskOption is a function that sets an option for the AutoAssignTask
+// function.
+type AutoAssignTaskOption func(*AutoAssignTaskOptions)
+
+// WithAutoAssignTaskSkipRates sets the skipRates option for the AutoAssignTask
+// function. If set to true, the function will not consider the rates of the
+// users when assigning the task.
+func WithAutoAssignTaskSkipRates() AutoAssignTaskOption {
+	return func(o *AutoAssignTaskOptions) {
+		o.skipRates = true
+	}
+}
+
+// WithAutoAssignTaskSkipWorkload sets the skipWorkload option for the
+// AutoAssignTask function. If set to true, the function will not consider the
+// workload of the users when assigning the task.
+func WithAutoAssignTaskSkipWorkload() AutoAssignTaskOption {
+	return func(o *AutoAssignTaskOptions) {
+		o.skipWorkload = true
+	}
+}
+
+// WithAutoAssignTaskSkipAssignment sets the skipAssignment option for the
+// AutoAssignTask function. If set to true, the function will not assign the
+// task to the users.
+func WithAutoAssignTaskSkipAssignment() AutoAssignTaskOption {
+	return func(o *AutoAssignTaskOptions) {
+		o.skipAssignment = true
+	}
+}
+
+// WithAutoAssignTaskSkipComment sets the skipComment option for the
+// AutoAssignTask function. If set to true, the function will not create a
+// comment on the task after assigning it.
+func WithAutoAssignTaskSkipComment() AutoAssignTaskOption {
+	return func(o *AutoAssignTaskOptions) {
+		o.skipComment = true
+	}
+}
+
+// AutoAssignTask assigns a task to users based on the skills and job roles
+// associated with the task.
+func AutoAssignTask(
+	ctx context.Context,
+	resources *config.Resources,
+	taskData webhook.TaskData,
+	optFuncs ...AutoAssignTaskOption,
+) error {
+	var options AutoAssignTaskOptions
+	for _, optFunc := range optFuncs {
+		optFunc(&options)
+	}
+
+	logger := resources.Logger.With(
+		slog.String("action", "autoAssignTask"),
+		slog.Int64("taskID", taskData.Task.ID),
+	)
+
+	if _, ok := processing.LoadOrStore(taskData.Task.ID, struct{}{}); ok {
+		logger.Info("task already being processed, skipping AI assignment")
+		return nil
+	}
+	defer processing.Delete(taskData.Task.ID)
+
+	// if there's already an assigned user, we don't need to do anything
+	if len(taskData.Task.AssignedUserIDs) > 0 {
+		logger.Info("task already has assigned users, skipping AI assignment")
+		return nil
+	}
+
+	skills, err := loadSkills(ctx, resources)
+	if err != nil {
+		return fmt.Errorf("failed to load skills: %w", err)
+	}
+	skillsMap := skills.toMap()
+
+	jobRoles, err := loadJobRoles(ctx, resources)
+	if err != nil {
+		return fmt.Errorf("failed to load job roles: %w", err)
+	}
+	jobRolesMap := jobRoles.toMap()
+
+	projectUsers, err := loadProjectUsers(ctx, resources, taskData.Project.ID)
+	if err != nil {
+		return fmt.Errorf("failed to load project users: %w", err)
+	}
+	projectUsersMap := projectUsers.toMap()
+
+	skillIDs, jobRoleIDs, reasoning, err := resources.Agentic.FindTaskSkillsAndJobRoles(ctx, taskData, skills, jobRoles)
+	if err != nil {
+		return fmt.Errorf("failed to find task skills and job roles: %w", err)
+	}
+
+	var userIDsWithSkills []int64
+	for _, skillID := range skillIDs {
+		skill, ok := skillsMap[skillID]
+		if !ok {
+			logger.Info("skill not found in the loaded skills, AI halucination",
+				slog.Int64("skillID", skillID),
+			)
+			continue
+		}
+		userIDsWithSkills = append(userIDsWithSkills, extractMappedIDs(skill.Users, projectUsersMap)...)
+	}
+
+	var userIDsWithJobRoles []int64
+	for _, jobRoleID := range jobRoleIDs {
+		jobRole, ok := jobRolesMap[jobRoleID]
+		if !ok {
+			logger.Info("job role not found in the loaded job roles, AI halucination",
+				slog.Int64("jobRoleID", jobRoleID),
+			)
+			continue
+		}
+		userIDsWithJobRoles = append(userIDsWithJobRoles, extractMappedIDs(jobRole.PrimaryUsers, projectUsersMap)...)
+		if len(jobRole.PrimaryUsers) == 0 {
+			userIDsWithJobRoles = append(userIDsWithJobRoles, extractMappedIDs(jobRole.Users, projectUsersMap)...)
+		}
+	}
+
+	idealUserIDs := intersection(userIDsWithSkills, userIDsWithJobRoles)
+	if len(idealUserIDs) == 0 {
+		idealUserIDs = append(idealUserIDs, userIDsWithSkills...)
+		idealUserIDs = append(idealUserIDs, userIDsWithJobRoles...)
+	}
+
+	if reasoning != "" && !strings.HasSuffix(reasoning, ".") {
+		reasoning += "."
+	}
+
+	var processors []autoAssignTaskProcessor
+	if !options.skipRates {
+		processors = append(processors, autoAssignTaskProcessRates(projectUsersMap, &reasoning, logger))
+	}
+	if !options.skipWorkload {
+		processors = append(processors, autoAssignTaskProcessWorkload(ctx, taskData, resources, &reasoning, logger))
+	}
+	userScores := newUserScores(idealUserIDs)
+	for _, processor := range processors {
+		if userScores, err = processor(userScores); err != nil {
+			return fmt.Errorf("failed to process ideal user IDs: %w", err)
+		}
+	}
+	idealUserIDs = userScores.chooseIDs()
+	if len(idealUserIDs) == 0 {
+		logger.Info("no users found with the AI suggested skills or job roles, skipping task assignment")
+		return nil
+	}
+
+	if !options.skipAssignment {
+		var taskUpdate task.Update
+		taskUpdate.ID = taskData.Task.ID
+		taskUpdate.Assignees = &teamwork.UserGroups{
+			UserIDs: idealUserIDs,
+		}
+		if err := resources.TeamworkEngine.Do(ctx, &taskUpdate); err != nil {
+			return fmt.Errorf("failed to assign task to users: %w", err)
+		}
+		logger.Info("task assigned to users based on AI",
+			slog.Int64("id", taskData.Task.ID),
+		)
+	}
+
+	if !options.skipComment {
+		var commentCreate comment.Create
+		commentCreate.Object = teamwork.Relationship{Type: "tasks", ID: taskData.Task.ID}
+		commentCreate.Body = "🤖 Assignment of this task was performed by artificial intelligence.\n"
+		for _, userID := range idealUserIDs {
+			if user, ok := projectUsersMap[userID]; ok {
+				commentCreate.Body += fmt.Sprintf("\n  • %s %s", user.FirstName, user.LastName)
+			}
+		}
+		commentCreate.Body += "\n\n" + reasoning
+		if err := resources.TeamworkEngine.Do(ctx, &commentCreate); err != nil {
+			return fmt.Errorf("failed to create comment: %w", err)
+		}
+	}
+
+	return nil
+}
+
+type userScore struct {
+	ID    int64
+	Score int64
+}
+
+type userScores []userScore
+
+func newUserScores(userIDs []int64) userScores {
+	userScores := make(userScores, len(userIDs))
+	for i, userID := range userIDs {
+		userScores[i] = userScore{
+			ID:    userID,
+			Score: 0,
+		}
+	}
+	return userScores
+}
+
+func (u userScores) ids() []int64 {
+	ids := make([]int64, len(u))
+	for i, userScore := range u {
+		ids[i] = userScore.ID
+	}
+	return ids
+}
+
+func (u userScores) chooseIDs() []int64 {
+	var highestScore int64
+	groupedIDs := make(map[int64][]int64)
+	for _, userScore := range u {
+		groupedIDs[userScore.Score] = append(groupedIDs[userScore.Score], userScore.ID)
+		if userScore.Score > highestScore {
+			highestScore = userScore.Score
+		}
+	}
+	return groupedIDs[highestScore]
+}
+
+type autoAssignTaskProcessor func(userIDs userScores) (userScores, error)
+
+func autoAssignTaskProcessRates(
+	projectUsersMap map[int64]user.User,
+	reasoning *string,
+	logger *slog.Logger,
+) autoAssignTaskProcessor {
+	type userCost struct {
+		ID   int64
+		Cost teamwork.Money
+	}
+	logger = logger.With(
+		slog.String("subAction", "processRates"),
+	)
+	return func(userScores userScores) (userScores, error) {
+		var userCosts []userCost
+		distinctCosts := make(map[teamwork.Money]struct{})
+		for _, userScore := range userScores {
+			user, ok := projectUsersMap[userScore.ID]
+			if !ok {
+				continue
+			}
+			if user.Cost == nil || *user.Cost == 0 || len(userCosts) == 0 {
+				var cost teamwork.Money
+				if user.Cost != nil {
+					cost = *user.Cost
+				}
+				userCosts = append(userCosts, userCost{
+					ID:   user.ID,
+					Cost: cost,
+				})
+				distinctCosts[cost] = struct{}{}
+				continue
+			}
+			for i := range userCosts {
+				if userCosts[i].Cost > *user.Cost {
+					userCosts = slices.Insert(userCosts, i, userCost{
+						ID:   user.ID,
+						Cost: *user.Cost,
+					})
+					distinctCosts[*user.Cost] = struct{}{}
+					break
+				}
+			}
+		}
+		weight := len(distinctCosts) + 1
+		userCostsWeights := make(map[int64]int, len(userCosts))
+		for i, userCost := range userCosts {
+			if i > 0 && userCosts[i-1].Cost == userCost.Cost {
+				userCostsWeights[userCost.ID] = weight
+			} else {
+				weight--
+				userCostsWeights[userCost.ID] = weight
+			}
+		}
+		var changed bool
+		for i, userScore := range userScores {
+			weight, ok := userCostsWeights[userScore.ID]
+			if !ok {
+				continue
+			}
+			userScore.Score += int64(weight)
+			userScores[i] = userScore
+			changed = true
+			logger.Debug("user score changed",
+				slog.Int64("userID", userScore.ID),
+				slog.Int("delta", weight),
+				slog.Int64("score", userScore.Score),
+			)
+		}
+		if changed && reasoning != nil {
+			if *reasoning != "" {
+				*reasoning += " "
+			}
+			*reasoning += "Concerns over user cost significantly impacted the decision."
+		}
+		return userScores, nil
+	}
+}
+
+func autoAssignTaskProcessWorkload(
+	ctx context.Context,
+	taskData webhook.TaskData,
+	resources *config.Resources,
+	reasoning *string,
+	logger *slog.Logger,
+) autoAssignTaskProcessor {
+	logger = logger.With(
+		slog.String("subAction", "processWorkload"),
+	)
+	return func(userScores userScores) (userScores, error) {
+		if taskData.Task.StartDate == nil || taskData.Task.DueDate == nil {
+			// without a window period, we can't calculate the workload
+			return userScores, nil
+		}
+
+		var single workload.Single
+		single.Request.Filters.StartDate = *taskData.Task.StartDate
+		single.Request.Filters.EndDate = *taskData.Task.DueDate
+		single.Request.Filters.UserIDs = userScores.ids()
+		single.Request.Filters.PageSize = int64(len(single.Request.Filters.UserIDs))
+		single.Request.Filters.Include = []string{"users.workingHours.workingHoursEntry"}
+
+		if err := resources.TeamworkEngine.Do(ctx, &single); err != nil {
+			return nil, fmt.Errorf("failed to load workload: %w", err)
+		}
+
+		availableUserIDs := make(map[int64]struct{})
+		for _, user := range single.Response.Workload.Users {
+			userIDStr := strconv.FormatInt(user.ID, 10)
+			var workingHoursID int64
+			if relationship := single.Response.Included.Users[userIDStr].WorkingHour; relationship != nil {
+				workingHoursID = relationship.ID
+			}
+
+			var availableHours float64
+			for date, dateData := range user.Dates {
+				var workingHours *float64
+				for _, entry := range single.Response.Included.WorkingHoursEntries {
+					if entry.WorkingHour.ID != workingHoursID {
+						continue
+					}
+					if weekday := strings.ToLower(time.Time(date).Weekday().String()); entry.Weekday == weekday {
+						workingHours = &entry.TaskHours
+						break
+					}
+				}
+				if workingHours == nil {
+					workingHours = func() *float64 {
+						var v float64
+						if single.Response.Included.Users != nil {
+							v = single.Response.Included.Users[userIDStr].LengthOfDay
+						}
+						if v == 0 {
+							// last resort to a default value
+							v = 8 // hours
+						}
+						return &v
+					}()
+				}
+				if !dateData.UnavailableDay {
+					availableHours += *workingHours - (float64(dateData.CapacityMinutes) / 60)
+				}
+			}
+
+			if availableHours > float64(taskData.Task.EstimatedMinutes)/60 {
+				availableUserIDs[user.ID] = struct{}{}
+			}
+		}
+		var changed bool
+		for i, userScore := range userScores {
+			if _, ok := availableUserIDs[userScore.ID]; !ok {
+				continue
+			}
+			userScore.Score += int64(len(userScores))
+			userScores[i] = userScore
+			changed = true
+			logger.Debug("user score changed",
+				slog.Int64("userID", userScore.ID),
+				slog.Int("delta", len(userScores)),
+				slog.Int64("score", userScore.Score),
+			)
+		}
+		if changed && reasoning != nil {
+			if *reasoning != "" {
+				*reasoning += " "
+			}
+			*reasoning += "Workload was a key consideration in the decision-making process."
+		}
+		return userScores, nil
+	}
+}
+
+type skills []skill.Skill
+
+func (s skills) toMap() map[int64]skill.Skill {
+	m := make(map[int64]skill.Skill, len(s))
+	for _, skill := range s {
+		m[skill.ID] = skill
+	}
+	return m
+}
+
+func loadSkills(ctx context.Context, resources *config.Resources) (skills, error) {
+	var multipleSkills skill.Multiple
+	multipleSkills.Request.Filters.Include = []string{"users"}
+	multipleSkills.Request.Filters.PageSize = 500 // TODO(@rafaeljusto): support pagination
+	if err := resources.TeamworkEngine.Do(ctx, &multipleSkills); err != nil {
+		return nil, fmt.Errorf("failed to load skills: %w", err)
+	}
+	return multipleSkills.Response.Skills, nil
+}
+
+type jobRoles []jobrole.JobRole
+
+func (j jobRoles) toMap() map[int64]jobrole.JobRole {
+	m := make(map[int64]jobrole.JobRole, len(j))
+	for _, jobRole := range j {
+		m[jobRole.ID] = jobRole
+	}
+	return m
+}
+
+func loadJobRoles(ctx context.Context, resources *config.Resources) (jobRoles, error) {
+	var multipleJobRoles jobrole.Multiple
+	multipleJobRoles.Request.Filters.Include = []string{"users"}
+	multipleJobRoles.Request.Filters.PageSize = 500 // TODO(@rafaeljusto): support pagination
+	if err := resources.TeamworkEngine.Do(ctx, &multipleJobRoles); err != nil {
+		return nil, fmt.Errorf("failed to load job roles: %w", err)
+	}
+	return multipleJobRoles.Response.JobRoles, nil
+}
+
+type projectUsers []user.User
+
+func (p projectUsers) toMap() map[int64]user.User {
+	m := make(map[int64]user.User, len(p))
+	for _, user := range p {
+		m[user.ID] = user
+	}
+	return m
+}
+
+func loadProjectUsers(ctx context.Context, resources *config.Resources, projectID int64) (projectUsers, error) {
+	var projectUsers user.Multiple
+	projectUsers.Request.Path.ProjectID = projectID
+	projectUsers.Request.Filters.PageSize = 500 // TODO(@rafaeljusto): support pagination
+	if err := resources.TeamworkEngine.Do(ctx, &projectUsers); err != nil {
+		return nil, fmt.Errorf("failed to load project users: %w", err)
+	}
+	return projectUsers.Response.Users, nil
+}

--- a/internal/agentic/actions/assigner_test.go
+++ b/internal/agentic/actions/assigner_test.go
@@ -1,0 +1,313 @@
+package actions_test
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/rafaeljusto/teamwork-ai/internal/agentic/actions"
+	"github.com/rafaeljusto/teamwork-ai/internal/config"
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork"
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/comment"
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/jobrole"
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/skill"
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/task"
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/user"
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/workload"
+	"github.com/rafaeljusto/teamwork-ai/internal/webhook"
+)
+
+func Test_AutoAssignTask(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources *config.Resources
+		taskData  webhook.TaskData
+		options   []actions.AutoAssignTaskOption
+	}{{
+		name: "it should assign a task and comment without checking rates or workload",
+		resources: &config.Resources{
+			TeamworkEngine: engineMock{
+				do: teamworkEngine([]user.User{
+					{ID: 1, FirstName: "James", LastName: "Smith"},
+					{ID: 2, FirstName: "Michael", LastName: "Williams"},
+				}, false, false),
+			},
+			Agentic: agenticMock{
+				findTaskSkillsAndJobRoles: func(
+					_ context.Context,
+					taskData webhook.TaskData,
+					availableSkills []skill.Skill,
+					availableJobRoles []jobrole.JobRole,
+				) ([]int64, []int64, string, error) {
+					if taskData.Task.ID != 1 {
+						return nil, nil, "", fmt.Errorf("unexpected task ID: %d", taskData.Task.ID)
+					}
+					if len(availableSkills) != 2 {
+						return nil, nil, "", fmt.Errorf("unexpected number of skills: %d", len(availableSkills))
+					}
+					if len(availableJobRoles) != 2 {
+						return nil, nil, "", fmt.Errorf("unexpected number of job roles: %d", len(availableJobRoles))
+					}
+					return []int64{1}, []int64{}, "Some interesting explanation.", nil
+				},
+			},
+			Logger: slog.New(slog.DiscardHandler),
+		},
+		taskData: func() webhook.TaskData {
+			var taskData webhook.TaskData
+			taskData.Task.ID = 1
+			taskData.Task.Name = "task-1"
+			return taskData
+		}(),
+		options: []actions.AutoAssignTaskOption{
+			actions.WithAutoAssignTaskSkipRates(),
+			actions.WithAutoAssignTaskSkipWorkload(),
+		},
+	}, {
+		name: "it should assign a task and comment checking rates and not workload",
+		resources: &config.Resources{
+			TeamworkEngine: engineMock{
+				do: teamworkEngine([]user.User{
+					{ID: 2, FirstName: "Michael", LastName: "Williams"},
+				}, true, false),
+			},
+			Agentic: agenticMock{
+				findTaskSkillsAndJobRoles: func(
+					_ context.Context,
+					taskData webhook.TaskData,
+					availableSkills []skill.Skill,
+					availableJobRoles []jobrole.JobRole,
+				) ([]int64, []int64, string, error) {
+					if taskData.Task.ID != 1 {
+						return nil, nil, "", fmt.Errorf("unexpected task ID: %d", taskData.Task.ID)
+					}
+					if len(availableSkills) != 2 {
+						return nil, nil, "", fmt.Errorf("unexpected number of skills: %d", len(availableSkills))
+					}
+					if len(availableJobRoles) != 2 {
+						return nil, nil, "", fmt.Errorf("unexpected number of job roles: %d", len(availableJobRoles))
+					}
+					return []int64{1}, []int64{}, "Some interesting explanation.", nil
+				},
+			},
+			Logger: slog.New(slog.DiscardHandler),
+		},
+		taskData: func() webhook.TaskData {
+			var taskData webhook.TaskData
+			taskData.Task.ID = 1
+			taskData.Task.Name = "task-1"
+			return taskData
+		}(),
+		options: []actions.AutoAssignTaskOption{
+			actions.WithAutoAssignTaskSkipWorkload(),
+		},
+	}, {
+		name: "it should assign a task and comment checking workload and not rates",
+		resources: &config.Resources{
+			TeamworkEngine: engineMock{
+				do: teamworkEngine([]user.User{
+					{ID: 2, FirstName: "Michael", LastName: "Williams"},
+				}, false, true),
+			},
+			Agentic: agenticMock{
+				findTaskSkillsAndJobRoles: func(
+					_ context.Context,
+					taskData webhook.TaskData,
+					availableSkills []skill.Skill,
+					availableJobRoles []jobrole.JobRole,
+				) ([]int64, []int64, string, error) {
+					if taskData.Task.ID != 1 {
+						return nil, nil, "", fmt.Errorf("unexpected task ID: %d", taskData.Task.ID)
+					}
+					if len(availableSkills) != 2 {
+						return nil, nil, "", fmt.Errorf("unexpected number of skills: %d", len(availableSkills))
+					}
+					if len(availableJobRoles) != 2 {
+						return nil, nil, "", fmt.Errorf("unexpected number of job roles: %d", len(availableJobRoles))
+					}
+					return []int64{1}, []int64{}, "Some interesting explanation.", nil
+				},
+			},
+			Logger: slog.New(slog.DiscardHandler),
+		},
+		taskData: func() webhook.TaskData {
+			var taskData webhook.TaskData
+			taskData.Task.ID = 1
+			taskData.Task.Name = "task-1"
+			taskData.Task.StartDate = pointerTo(teamwork.Date(time.Now().AddDate(0, 0, 1)))
+			taskData.Task.DueDate = pointerTo(teamwork.Date(time.Now().AddDate(0, 0, 2)))
+			taskData.Task.EstimatedMinutes = 120
+			return taskData
+		}(),
+		options: []actions.AutoAssignTaskOption{
+			actions.WithAutoAssignTaskSkipRates(),
+		},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := actions.AutoAssignTask(
+				context.Background(),
+				tt.resources,
+				tt.taskData,
+				tt.options...,
+			); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func pointerTo[T any](t T) *T {
+	return &t
+}
+
+type engineMock struct {
+	do func(context.Context, teamwork.Entity, ...teamwork.Option) error
+}
+
+func (e engineMock) Do(ctx context.Context, entity teamwork.Entity, optFuncs ...teamwork.Option) error {
+	return e.do(ctx, entity, optFuncs...)
+}
+
+type agenticMock struct {
+	findTaskSkillsAndJobRoles func(
+		context.Context,
+		webhook.TaskData,
+		[]skill.Skill,
+		[]jobrole.JobRole,
+	) ([]int64, []int64, string, error)
+}
+
+func (a agenticMock) Init(string, *slog.Logger) error {
+	return nil
+}
+
+func (a agenticMock) FindTaskSkillsAndJobRoles(
+	ctx context.Context,
+	taskData webhook.TaskData,
+	availableSkills []skill.Skill,
+	availableJobRoles []jobrole.JobRole,
+) ([]int64, []int64, string, error) {
+	return a.findTaskSkillsAndJobRoles(ctx, taskData, availableSkills, availableJobRoles)
+}
+
+func teamworkEngine(
+	expectedAssignees []user.User,
+	useRate, useWorkload bool,
+) func(context.Context, teamwork.Entity, ...teamwork.Option) error {
+	return func(_ context.Context, entity teamwork.Entity, _ ...teamwork.Option) error {
+		switch t := entity.(type) {
+		case *skill.Multiple:
+			t.Response.Skills = []skill.Skill{
+				{
+					ID:   1,
+					Name: "skill-1",
+					Users: []teamwork.Relationship{
+						{ID: 1, Type: "users"},
+						{ID: 2, Type: "users"},
+					},
+				},
+				{
+					ID:   2,
+					Name: "skill-2",
+					Users: []teamwork.Relationship{
+						{ID: 2, Type: "users"},
+					},
+				},
+			}
+		case *jobrole.Multiple:
+			t.Response.JobRoles = []jobrole.JobRole{
+				{
+					ID:   1,
+					Name: "jobrole-1",
+					Users: []teamwork.Relationship{
+						{ID: 1, Type: "users"},
+						{ID: 2, Type: "users"},
+					},
+				},
+				{
+					ID:   2,
+					Name: "jobrole-2",
+					Users: []teamwork.Relationship{
+						{ID: 2, Type: "users"},
+					},
+				},
+			}
+		case *user.Multiple:
+			t.Response.Users = []user.User{
+				{ID: 1, FirstName: "James", LastName: "Smith", Cost: pointerTo(teamwork.Money(20000))},
+				{ID: 2, FirstName: "Michael", LastName: "Williams", Cost: pointerTo(teamwork.Money(10000))},
+			}
+		case *workload.Single:
+			t.Response.Workload.Users = []workload.User{
+				{
+					ID: 1,
+					Dates: map[teamwork.Date]workload.UserDate{
+						teamwork.Date(time.Now().AddDate(0, 0, 1)): {
+							Capacity:        87.5,
+							CapacityMinutes: 420,
+							UnavailableDay:  false,
+						},
+						teamwork.Date(time.Now().AddDate(0, 0, 2)): {
+							UnavailableDay: true,
+						},
+					},
+				},
+				{
+					ID: 2,
+					Dates: map[teamwork.Date]workload.UserDate{
+						teamwork.Date(time.Now().AddDate(0, 0, 1)): {
+							Capacity:        10,
+							CapacityMinutes: 48,
+							UnavailableDay:  false,
+						},
+						teamwork.Date(time.Now().AddDate(0, 0, 2)): {
+							Capacity:        80,
+							CapacityMinutes: 384,
+							UnavailableDay:  false,
+						},
+					},
+				},
+			}
+		case *task.Update:
+			if t.ID != 1 {
+				return fmt.Errorf("unexpected task ID: %d", t.ID)
+			}
+			if len(t.Assignees.UserIDs) != len(expectedAssignees) {
+				return fmt.Errorf("unexpected number of assigned users: %d", len(t.Assignees.UserIDs))
+			}
+			for i, expectedAssignee := range expectedAssignees {
+				if t.Assignees.UserIDs[i] != expectedAssignee.ID {
+					return fmt.Errorf("unexpected assigned user ID at index %d: %d", i, t.Assignees.UserIDs[i])
+				}
+			}
+		case *comment.Create:
+			if t.Object.Type != "tasks" {
+				return fmt.Errorf("unexpected comment object type: %s", t.Object.Type)
+			}
+			if t.Object.ID != 1 {
+				return fmt.Errorf("unexpected comment object ID: %d", t.Object.ID)
+			}
+			expectedBody := "🤖 Assignment of this task was performed by artificial intelligence.\n"
+			for _, user := range expectedAssignees {
+				expectedBody += fmt.Sprintf("\n  • %s %s", user.FirstName, user.LastName)
+			}
+			expectedBody += "\n\nSome interesting explanation."
+			if useRate {
+				expectedBody += " Concerns over user cost significantly impacted the decision."
+			}
+			if useWorkload {
+				expectedBody += " Workload was a key consideration in the decision-making process."
+			}
+			if t.Body != expectedBody {
+				return fmt.Errorf("unexpected comment body: %s", t.Body)
+			}
+		default:
+			return fmt.Errorf("unexpected entity type: %T", t)
+		}
+		return nil
+	}
+}

--- a/internal/agentic/actions/docs.go
+++ b/internal/agentic/actions/docs.go
@@ -1,0 +1,3 @@
+// Package actions provides a set of functions to perform various actions
+// related to the agentic system, including task assignment.
+package actions

--- a/internal/agentic/actions/utils.go
+++ b/internal/agentic/actions/utils.go
@@ -1,0 +1,45 @@
+package actions
+
+import (
+	"cmp"
+	"slices"
+	"sort"
+
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork"
+)
+
+// intersection returns the intersection of two slices. It will sort the slices
+// before performing the intersection. The slices must contain elements that
+// implement the comparable and cmp.Ordered interfaces.
+func intersection[T interface {
+	comparable
+	cmp.Ordered
+}](a []T, b []T) []T {
+	slices.Sort(a)
+	slices.Sort(b)
+
+	set := make([]T, 0)
+	for _, v := range a {
+		idx := sort.Search(len(b), func(i int) bool {
+			return b[i] == v
+		})
+		if idx < len(b) && b[idx] == v {
+			set = append(set, v)
+		}
+	}
+	return set
+}
+
+// extractMappedIDs ensure that only IDs from relationships mapped to the source
+// are returned.
+func extractMappedIDs[T any](relationships []teamwork.Relationship, sourceMap map[int64]T) []int64 {
+	result := make([]int64, 0, len(relationships))
+	for _, relationship := range relationships {
+		_, ok := sourceMap[relationship.ID]
+		if !ok {
+			continue
+		}
+		result = append(result, relationship.ID)
+	}
+	return result
+}

--- a/internal/agentic/agentic.go
+++ b/internal/agentic/agentic.go
@@ -1,0 +1,57 @@
+package agentic
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/jobrole"
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/skill"
+	"github.com/rafaeljusto/teamwork-ai/internal/webhook"
+)
+
+var registered map[string]Agentic
+
+// Register registers an agentic implementation with the given name. The name is
+// used to identify the agentic implementation when initializing it. The agentic
+// implementation must implement the Agentic interface.
+func Register(name string, agentic Agentic) {
+	if registered == nil {
+		registered = make(map[string]Agentic)
+	}
+	registered[name] = agentic
+}
+
+// Init initializes the agentic system with the provided name, and DSN. The name
+// must be from a pre-registered agentic implementation. The DSN is specific to
+// the agentic implementation and is used to configure it.
+func Init(name, dsn string, logger *slog.Logger) Agentic {
+	if name == "" {
+		return nil
+	}
+	agentic, ok := registered[name]
+	if !ok {
+		panic(fmt.Errorf("unknown agentic implementation: %s", name))
+	}
+	if err := agentic.Init(dsn, logger); err != nil {
+		panic(fmt.Errorf("failed to initialize agentic implementation: %w", err))
+	}
+	return agentic
+}
+
+// Agentic stores mechanisms to build autonomous systems capable of making
+// decisions and performing tasks without constant human intervention.
+type Agentic interface {
+	// Init initializes the agentic system with the provided DSN.
+	Init(dsn string, logger *slog.Logger) error
+
+	// FindTaskSkillsAndJobRoles finds the skills and job roles for a given task.
+	// It uses the task data, available skills, and available job roles to
+	// determine the most relevant skills and job roles IDs for the task.
+	FindTaskSkillsAndJobRoles(
+		ctx context.Context,
+		taskDate webhook.TaskData,
+		availableSkills []skill.Skill,
+		availableJobRoles []jobrole.JobRole,
+	) (skillIDs, jobRoleIDs []int64, reasoning string, err error)
+}

--- a/internal/agentic/anthropic/anthropic.go
+++ b/internal/agentic/anthropic/anthropic.go
@@ -1,0 +1,137 @@
+package anthropic
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/rafaeljusto/teamwork-ai/internal/agentic"
+)
+
+var _ agentic.Agentic = (*anthropic)(nil)
+
+func init() {
+	agentic.Register("anthropic", &anthropic{})
+}
+
+// anthropic is an american company that provides a suite of AI tools and
+// services. This specific instance implements all required functions to allow
+// the Teamwork AI agentic implementation. The Anthropic API is a cloud-based
+// service that provides access to Anthropic's language models, including Claude
+// 1 and Claude 2. It allows developers to integrate AI capabilities into their
+// applications, enabling tasks such as natural language understanding, text
+// generation, and conversation simulation.
+//
+// The API reference is available at:
+// https://docs.anthropic.com/en/api
+type anthropic struct {
+	client *http.Client
+	logger *slog.Logger
+	model  string
+	token  string
+}
+
+// Init initializes the anthropic instance with the provided DSN. The DSN must
+// have the format:
+//
+//	`model:token`.
+//
+// The model name should be the name of the model to be used (e.g.
+// "claude-1"). The token should be the Anthropic API key.
+//
+// TODO(rafaeljusto): Add support for custom HTTP client.
+func (a *anthropic) Init(dsn string, logger *slog.Logger) error {
+	a.client = http.DefaultClient
+	a.logger = logger
+
+	dsnParts := strings.Split(dsn, ":")
+	if len(dsnParts) != 2 {
+		return fmt.Errorf("invalid DSN format: %s", dsn)
+	}
+	a.model = dsnParts[0]
+	a.token = dsnParts[1]
+	return nil
+}
+
+func (a *anthropic) do(ctx context.Context, aiRequest request) (response, error) {
+	body, err := json.Marshal(aiRequest)
+	if err != nil {
+		return response{}, fmt.Errorf("failed to encode request: %w", err)
+	}
+
+	url := "https://api.anthropic.com/v1/messages"
+	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(body))
+	if err != nil {
+		return response{}, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpRequest.Header.Set("x-api-key", a.token)
+	httpRequest.Header.Set("anthropic-version", "2023-06-01")
+	httpRequest.Header.Set("Content-Type", "application/json")
+
+	httpResponse, err := a.client.Do(httpRequest)
+	if err != nil {
+		return response{}, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer func() {
+		if err := httpResponse.Body.Close(); err != nil {
+			a.logger.Error("failed to close response body",
+				slog.String("error", err.Error()),
+			)
+		}
+	}()
+
+	if httpResponse.StatusCode != http.StatusOK {
+		if body, err := io.ReadAll(httpResponse.Body); err == nil {
+			return response{}, fmt.Errorf("unexpected status code: %d, body: %s", httpResponse.StatusCode, string(body))
+		}
+		return response{}, fmt.Errorf("unexpected status code: %d", httpResponse.StatusCode)
+	}
+
+	var aiResponse response
+	if err = json.NewDecoder(httpResponse.Body).Decode(&aiResponse); err != nil {
+		return response{}, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return aiResponse, nil
+}
+
+type request struct {
+	Model     string           `json:"model"`
+	Messages  []requestMessage `json:"messages"`
+	MaxTokens int              `json:"max_tokens"`
+}
+
+func (r *request) addUserMessage(content string) {
+	r.Messages = append(r.Messages, requestMessage{
+		Role:    "user",
+		Content: content,
+	})
+}
+
+type requestMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type response struct {
+	Contents []content `json:"content"`
+}
+
+func (r *response) decode(target any) error {
+	if len(r.Contents) == 0 {
+		return fmt.Errorf("no content in response")
+	}
+	if len(r.Contents) > 1 {
+		return fmt.Errorf("multiple contents in response")
+	}
+	return json.Unmarshal([]byte(r.Contents[0].Text), target)
+}
+
+type content struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}

--- a/internal/agentic/anthropic/docs.go
+++ b/internal/agentic/anthropic/docs.go
@@ -1,0 +1,2 @@
+// Package anthropic provides an interface to the Anthropic API.
+package anthropic

--- a/internal/agentic/anthropic/task.go
+++ b/internal/agentic/anthropic/task.go
@@ -1,0 +1,84 @@
+package anthropic
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/jobrole"
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/skill"
+	"github.com/rafaeljusto/teamwork-ai/internal/webhook"
+)
+
+// FindTaskSkillsAndJobRoles finds the skills and job roles for a given task. It
+// uses the task data, available skills, and available job roles to determine
+// the most relevant skills and job roles IDs for the task.
+func (a *anthropic) FindTaskSkillsAndJobRoles(
+	ctx context.Context,
+	taskData webhook.TaskData,
+	availableSkills []skill.Skill,
+	availableJobRoles []jobrole.JobRole,
+) ([]int64, []int64, string, error) {
+	var encodedSkills string
+	for i, skill := range availableSkills {
+		if i > 0 {
+			encodedSkills += ", "
+		}
+		encodedSkills += fmt.Sprintf(`{"id": %d, "name": "%s"}`, skill.ID, skill.Name)
+	}
+
+	var encodedJobRoles string
+	for i, jobRole := range availableJobRoles {
+		if i > 0 {
+			encodedJobRoles += ", "
+		}
+		encodedJobRoles += fmt.Sprintf(`{"id": %d, "name": "%s"}`, jobRole.ID, jobRole.Name)
+	}
+
+	var aiRequest request
+	aiRequest.Model = a.model
+	aiRequest.MaxTokens = 1024
+	aiRequest.addUserMessage(findTaskSkillsAndJobRolesPrompt)
+	aiRequest.addUserMessage("Project name: " + taskData.Project.Name)
+	aiRequest.addUserMessage("Project description: " + taskData.Project.Description)
+	aiRequest.addUserMessage("Tasklist name: " + taskData.Tasklist.Name)
+	aiRequest.addUserMessage("Tasklist description: " + taskData.Tasklist.Description)
+	aiRequest.addUserMessage("Task name: " + taskData.Task.Name)
+	aiRequest.addUserMessage("Task description: " + taskData.Task.Description)
+	aiRequest.addUserMessage("Available skills: " + encodedSkills)
+	aiRequest.addUserMessage("Available job roles: " + encodedJobRoles)
+
+	aiResponse, err := a.do(ctx, aiRequest)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("failed to find task skills and job roles: %w", err)
+	}
+
+	var skillAndJobRoles struct {
+		SkillIDs   []int64 `json:"skillIds"`
+		JobRoleIDs []int64 `json:"jobRoleIds"`
+		Reasoning  string  `json:"reasoning"`
+	}
+	if err := aiResponse.decode(&skillAndJobRoles); err != nil {
+		return nil, nil, "", fmt.Errorf("failed to decode task skills and job roles: %w", err)
+	}
+	return skillAndJobRoles.SkillIDs, skillAndJobRoles.JobRoleIDs, skillAndJobRoles.Reasoning, nil
+}
+
+const findTaskSkillsAndJobRolesPrompt = `
+You are an project manager expert. You have access to a list of skills and job
+roles that can be used to complete a task. You are given a task with its name,
+description, and the project it belongs to. You need to analyze the task and
+suggest the best skills and job roles to complete it.
+
+Please send back a JSON object with the skills and job role IDs. The format
+MUST be:
+
+{
+  "skillIds": [1, 2],
+  "jobRoleIds": [3, 4]
+  "reasoning": "The reasoning behind the suggestions"
+}
+
+You MUST NOT send anything else, just the JSON object. If there are no skills or
+job roles, send an empty array. Do not allucinate or make up any skills or job
+roles.
+`

--- a/internal/agentic/docs.go
+++ b/internal/agentic/docs.go
@@ -1,0 +1,3 @@
+// Package agentic provides the interface to the agentic system. It can have
+// multiple LLM implementations using different APIs.
+package agentic

--- a/internal/agentic/ollama/docs.go
+++ b/internal/agentic/ollama/docs.go
@@ -1,0 +1,2 @@
+// Package ollama provides the Ollama LLM implementation.
+package ollama

--- a/internal/agentic/ollama/ollama.go
+++ b/internal/agentic/ollama/ollama.go
@@ -1,0 +1,136 @@
+package ollama
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+
+	"github.com/rafaeljusto/teamwork-ai/internal/agentic"
+)
+
+var _ agentic.Agentic = (*ollama)(nil)
+
+func init() {
+	agentic.Register("ollama", &ollama{})
+}
+
+// ollama is an open-source, cross-platform framework that simplifies running
+// large language models (LLMs) locally on your computer. This specific instance
+// implements all required functions to allow the Teamwork AI agentic
+// implementation.
+//
+// The API reference is available at:
+// https://github.com/ollama/ollama/blob/6a74bba7e7e19bf5f5aeacb039a1537afa3522a5/docs/api.md
+type ollama struct {
+	server string
+	client *http.Client
+	model  string
+	logger *slog.Logger
+}
+
+// Init initializes the Ollama instance with the provided DSN. The DSN must have
+// the format:
+//
+//	`http[s]://[username[:password]@]host[:port]/model`.
+//
+// The server URL should point to the Ollama base URL, and the model name should
+// be the name of the model to be used (e.g. "llama3.2").
+//
+// TODO(rafaeljusto): Add support for custom HTTP client.
+func (o *ollama) Init(dsn string, logger *slog.Logger) error {
+	o.client = http.DefaultClient
+	o.logger = logger
+
+	parsedURL, err := url.Parse(dsn)
+	if err != nil {
+		return fmt.Errorf("failed to parse DSN: %w", err)
+	}
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return fmt.Errorf("invalid scheme: %s", parsedURL.Scheme)
+	}
+	if parsedURL.Path == "" {
+		return fmt.Errorf("missing model name in DSN")
+	}
+	o.model = parsedURL.Path[1:]
+
+	parsedURL.Path = ""
+	o.server = parsedURL.String()
+	return nil
+}
+
+func (o *ollama) do(ctx context.Context, aiRequest request) (response, error) {
+	body, err := json.Marshal(aiRequest)
+	if err != nil {
+		return response{}, fmt.Errorf("failed to encode request: %w", err)
+	}
+
+	url, err := url.JoinPath(o.server, "/api/chat")
+	if err != nil {
+		return response{}, fmt.Errorf("failed to build url: %w", err)
+	}
+
+	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(body))
+	if err != nil {
+		return response{}, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpRequest.Header.Set("Content-Type", "application/json")
+
+	httpResponse, err := o.client.Do(httpRequest)
+	if err != nil {
+		return response{}, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer func() {
+		if err := httpResponse.Body.Close(); err != nil {
+			o.logger.Error("failed to close response body",
+				slog.String("error", err.Error()),
+			)
+		}
+	}()
+
+	if httpResponse.StatusCode != http.StatusOK {
+		if body, err := io.ReadAll(httpResponse.Body); err == nil {
+			return response{}, fmt.Errorf("unexpected status code: %d, body: %s", httpResponse.StatusCode, string(body))
+		}
+		return response{}, fmt.Errorf("unexpected status code: %d", httpResponse.StatusCode)
+	}
+
+	var aiResponse response
+	if err = json.NewDecoder(httpResponse.Body).Decode(&aiResponse); err != nil {
+		return response{}, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return aiResponse, nil
+}
+
+type request struct {
+	Model    string           `json:"model"`
+	Messages []requestMessage `json:"messages"`
+	Stream   bool             `json:"stream"`
+}
+
+func (r *request) addUserMessage(content string) {
+	r.Messages = append(r.Messages, requestMessage{
+		Role:    "user",
+		Content: content,
+	})
+}
+
+type requestMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type response struct {
+	Message struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	} `json:"message"`
+}
+
+func (r *response) decode(target any) error {
+	return json.Unmarshal([]byte(r.Message.Content), target)
+}

--- a/internal/agentic/ollama/task.go
+++ b/internal/agentic/ollama/task.go
@@ -1,0 +1,83 @@
+package ollama
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/jobrole"
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/skill"
+	"github.com/rafaeljusto/teamwork-ai/internal/webhook"
+)
+
+// FindTaskSkillsAndJobRoles finds the skills and job roles for a given task. It
+// uses the task data, available skills, and available job roles to determine
+// the most relevant skills and job roles IDs for the task.
+func (o *ollama) FindTaskSkillsAndJobRoles(
+	ctx context.Context,
+	taskData webhook.TaskData,
+	availableSkills []skill.Skill,
+	availableJobRoles []jobrole.JobRole,
+) ([]int64, []int64, string, error) {
+	var encodedSkills string
+	for i, skill := range availableSkills {
+		if i > 0 {
+			encodedSkills += ", "
+		}
+		encodedSkills += fmt.Sprintf(`{"id": %d, "name": "%s"}`, skill.ID, skill.Name)
+	}
+
+	var encodedJobRoles string
+	for i, jobRole := range availableJobRoles {
+		if i > 0 {
+			encodedJobRoles += ", "
+		}
+		encodedJobRoles += fmt.Sprintf(`{"id": %d, "name": "%s"}`, jobRole.ID, jobRole.Name)
+	}
+
+	var aiRequest request
+	aiRequest.Model = o.model
+	aiRequest.addUserMessage(findTaskSkillsAndJobRolesPrompt)
+	aiRequest.addUserMessage("Project name: " + taskData.Project.Name)
+	aiRequest.addUserMessage("Project description: " + taskData.Project.Description)
+	aiRequest.addUserMessage("Tasklist name: " + taskData.Tasklist.Name)
+	aiRequest.addUserMessage("Tasklist description: " + taskData.Tasklist.Description)
+	aiRequest.addUserMessage("Task name: " + taskData.Task.Name)
+	aiRequest.addUserMessage("Task description: " + taskData.Task.Description)
+	aiRequest.addUserMessage("Available skills: " + encodedSkills)
+	aiRequest.addUserMessage("Available job roles: " + encodedJobRoles)
+
+	aiResponse, err := o.do(ctx, aiRequest)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("failed to find task skills and job roles: %w", err)
+	}
+
+	var skillAndJobRoles struct {
+		SkillIDs   []int64 `json:"skillIds"`
+		JobRoleIDs []int64 `json:"jobRoleIds"`
+		Reasoning  string  `json:"reasoning"`
+	}
+	if err := aiResponse.decode(&skillAndJobRoles); err != nil {
+		return nil, nil, "", fmt.Errorf("failed to decode task skills and job roles: %w", err)
+	}
+	return skillAndJobRoles.SkillIDs, skillAndJobRoles.JobRoleIDs, skillAndJobRoles.Reasoning, nil
+}
+
+const findTaskSkillsAndJobRolesPrompt = `
+You are an project manager expert. You have access to a list of skills and job
+roles that can be used to complete a task. You are given a task with its name,
+description, and the project it belongs to. You need to analyze the task and
+suggest the best skills and job roles to complete it.
+
+Please send back a JSON object with the skills and job role IDs. The format
+MUST be:
+
+{
+  "skillIds": [1, 2],
+  "jobRoleIds": [3, 4]
+  "reasoning": "The reasoning behind the suggestions"
+}
+
+You MUST NOT send anything else, just the JSON object. If there are no skills or
+job roles, send an empty array. Do not allucinate or make up any skills or job
+roles.
+`

--- a/internal/agentic/openai/docs.go
+++ b/internal/agentic/openai/docs.go
@@ -1,0 +1,2 @@
+// Package openai provides a client for the OpenAI API.
+package openai

--- a/internal/agentic/openai/openai.go
+++ b/internal/agentic/openai/openai.go
@@ -1,0 +1,136 @@
+package openai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/rafaeljusto/teamwork-ai/internal/agentic"
+)
+
+var _ agentic.Agentic = (*openai)(nil)
+
+func init() {
+	agentic.Register("openai", &openai{})
+}
+
+// openai is an american company that provides a suite of AI tools and services.
+// This specific instance implements all required functions to allow the
+// Teamwork AI agentic implementation. The OpenAI API is a cloud-based service
+// that provides access to OpenAI's language models, including GPT-3.5 and
+// GPT-4. It allows developers to integrate AI capabilities into their
+// applications, enabling tasks such as natural language understanding, text
+// generation, and conversation simulation.
+//
+// The API reference is available at:
+// https://platform.openai.com/docs/api-reference/introduction
+type openai struct {
+	client *http.Client
+	logger *slog.Logger
+	model  string
+	token  string
+}
+
+// Init initializes the OpenAI instance with the provided DSN. The DSN must have
+// the format:
+//
+//	`model:token`.
+//
+// The model name should be the name of the model to be used (e.g.
+// "gpt-3.5-turbo"). The token should be the OpenAI API key.
+//
+// TODO(rafaeljusto): Add support for custom HTTP client.
+func (o *openai) Init(dsn string, logger *slog.Logger) error {
+	o.client = http.DefaultClient
+	o.logger = logger
+
+	dsnParts := strings.Split(dsn, ":")
+	if len(dsnParts) != 2 {
+		return fmt.Errorf("invalid DSN format: %s", dsn)
+	}
+	o.model = dsnParts[0]
+	o.token = dsnParts[1]
+	return nil
+}
+
+func (o *openai) do(ctx context.Context, aiRequest request) (response, error) {
+	body, err := json.Marshal(aiRequest)
+	if err != nil {
+		return response{}, fmt.Errorf("failed to encode request: %w", err)
+	}
+
+	url := "https://api.openai.com/v1/responses"
+	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(body))
+	if err != nil {
+		return response{}, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpRequest.Header.Set("Authorization", "Bearer "+o.token)
+	httpRequest.Header.Set("Content-Type", "application/json")
+
+	httpResponse, err := o.client.Do(httpRequest)
+	if err != nil {
+		return response{}, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer func() {
+		if err := httpResponse.Body.Close(); err != nil {
+			o.logger.Error("failed to close response body",
+				slog.String("error", err.Error()),
+			)
+		}
+	}()
+
+	if httpResponse.StatusCode != http.StatusOK {
+		if body, err := io.ReadAll(httpResponse.Body); err == nil {
+			return response{}, fmt.Errorf("unexpected status code: %d, body: %s", httpResponse.StatusCode, string(body))
+		}
+		return response{}, fmt.Errorf("unexpected status code: %d", httpResponse.StatusCode)
+	}
+
+	var aiResponse response
+	if err = json.NewDecoder(httpResponse.Body).Decode(&aiResponse); err != nil {
+		return response{}, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return aiResponse, nil
+}
+
+type request struct {
+	Model string `json:"model"`
+	Input string `json:"prompt"`
+}
+
+type response struct {
+	Output []output `json:"output"`
+}
+
+func (r *response) decode(target any) error {
+	if len(r.Output) == 0 {
+		return fmt.Errorf("no outputs in response")
+	}
+	if len(r.Output) > 1 {
+		return fmt.Errorf("multiple outputs in response")
+	}
+	if len(r.Output[0].Content) == 0 {
+		return fmt.Errorf("no content in output")
+	}
+	if len(r.Output[0].Content) > 1 {
+		return fmt.Errorf("multiple contents in output")
+	}
+	return json.Unmarshal([]byte(r.Output[0].Content[0].Text), target)
+}
+
+type output struct {
+	Type    string    `json:"type"`
+	Status  string    `json:"status"`
+	Role    string    `json:"role"`
+	Content []content `json:"content"`
+}
+
+type content struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}

--- a/internal/agentic/openai/task.go
+++ b/internal/agentic/openai/task.go
@@ -1,0 +1,138 @@
+package openai
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"text/template"
+
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/jobrole"
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/skill"
+	"github.com/rafaeljusto/teamwork-ai/internal/webhook"
+)
+
+var findTaskSkillsAndJobRolesCompiled = template.Must(template.New("prompt").Parse(findTaskSkillsAndJobRolesPrompt))
+
+// FindTaskSkillsAndJobRoles finds the skills and job roles for a given task. It
+// uses the task data, available skills, and available job roles to determine
+// the most relevant skills and job roles IDs for the task.
+func (o *openai) FindTaskSkillsAndJobRoles(
+	ctx context.Context,
+	taskData webhook.TaskData,
+	availableSkills []skill.Skill,
+	availableJobRoles []jobrole.JobRole,
+) ([]int64, []int64, string, error) {
+	var promptBuffer bytes.Buffer
+	templateData := newFindTaskSkillsAndJobRolesData(taskData, availableSkills, availableJobRoles)
+	if err := findTaskSkillsAndJobRolesCompiled.Execute(&promptBuffer, templateData); err != nil {
+		return nil, nil, "", fmt.Errorf("failed to execute prompt template: %w", err)
+	}
+
+	var aiRequest request
+	aiRequest.Model = o.model
+	aiRequest.Input = promptBuffer.String()
+
+	aiResponse, err := o.do(ctx, aiRequest)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("failed to find task skills and job roles: %w", err)
+	}
+
+	var skillAndJobRoles struct {
+		SkillIDs   []int64 `json:"skillIds"`
+		JobRoleIDs []int64 `json:"jobRoleIds"`
+		Reasoning  string  `json:"reasoning"`
+	}
+	if err := aiResponse.decode(&skillAndJobRoles); err != nil {
+		return nil, nil, "", fmt.Errorf("failed to decode task skills and job roles: %w", err)
+	}
+	return skillAndJobRoles.SkillIDs, skillAndJobRoles.JobRoleIDs, skillAndJobRoles.Reasoning, nil
+}
+
+type findTaskSkillsAndJobRolesData struct {
+	Project struct {
+		Name        string
+		Description string
+	}
+	Tasklist struct {
+		Name        string
+		Description string
+	}
+	Task struct {
+		Name        string
+		Description string
+	}
+	Skills   []idName
+	JobRoles []idName
+}
+
+type idName struct {
+	ID   int64
+	Name string
+}
+
+// Encode encodes the idName struct into a JSON string.
+func (i idName) Encode() string {
+	return fmt.Sprintf(`{"id":%d,"name":"%s"}`, i.ID, i.Name)
+}
+
+func newFindTaskSkillsAndJobRolesData(
+	taskData webhook.TaskData,
+	skills []skill.Skill,
+	jobRoles []jobrole.JobRole,
+) findTaskSkillsAndJobRolesData {
+	var data findTaskSkillsAndJobRolesData
+	data.Project.Name = taskData.Project.Name
+	data.Project.Description = taskData.Project.Description
+	data.Tasklist.Name = taskData.Tasklist.Name
+	data.Tasklist.Description = taskData.Tasklist.Description
+	data.Task.Name = taskData.Task.Name
+	data.Task.Description = taskData.Task.Description
+
+	for _, skill := range skills {
+		data.Skills = append(data.Skills, idName{ID: skill.ID, Name: skill.Name})
+	}
+
+	for _, jobRole := range jobRoles {
+		data.JobRoles = append(data.JobRoles, idName{ID: jobRole.ID, Name: jobRole.Name})
+	}
+
+	return data
+}
+
+//noling:lll
+const findTaskSkillsAndJobRolesPrompt = `
+You are an project manager expert. You have access to a list of skills and job
+roles that can be used to complete a task. You are given a task with its name,
+description, and the project it belongs to. You need to analyze the task and
+suggest the best skills and job roles to complete it.
+
+Please send back a JSON object with the skills and job role IDs. The format
+MUST be:
+
+{
+  "skillIds": [1, 2],
+  "jobRoleIds": [3, 4]
+  "reasoning": "The reasoning behind the suggestions"
+}
+
+You MUST NOT send anything else, just the JSON object. If there are no skills or
+job roles, send an empty array. Do not allucinate or make up any skills or job
+roles.
+
+---
+Project name: {{.Project.Name}}
+---
+Project description: {{.Project.Description}}
+---
+Tasklist name: {{.Tasklist.Name}}
+---
+Tasklist description: {{.Tasklist.Description}}
+---
+Task name: {{.Task.Name}}
+---
+Task description: {{.Task.Description}}
+---
+Available skills: {{range $i, $skill := .Skills}}{{if gt $i 0}},{{end}}{{$skill.Encode}}{{end}}
+---
+Available job roles: {{range $i, $jobRole := .JobRoles}}{{if gt $i 0}},{{end}}{{$jobRole.Encode}}{{end}}
+`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,16 @@ type Config struct {
 
 	// TeamworkAPIToken is the API token of the Teamwork API.
 	TeamworkAPIToken string
+
+	// Agentic is the agentic configuration.
+	Agentic struct {
+		// Name is the name of the agentic implementation.
+		Name string
+
+		// DSN is the data source name for the agentic model. The format depends on
+		// the chosen implementation.
+		DSN string
+	}
 }
 
 // ParseFromEnvs parses the configuration from environment variables.
@@ -47,6 +57,9 @@ func ParseFromEnvs() (*Config, error) {
 
 	config.TeamworkServer = os.Getenv("TWAI_TEAMWORK_SERVER")
 	config.TeamworkAPIToken = os.Getenv("TWAI_TEAMWORK_API_TOKEN")
+
+	config.Agentic.Name = os.Getenv("TWAI_AGENTIC_NAME")
+	config.Agentic.DSN = os.Getenv("TWAI_AGENTIC_DSN")
 
 	if errs != nil {
 		return nil, errs

--- a/internal/config/resources.go
+++ b/internal/config/resources.go
@@ -5,12 +5,14 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/rafaeljusto/teamwork-ai/internal/agentic"
 	"github.com/rafaeljusto/teamwork-ai/internal/teamwork"
 )
 
 // Resources stores the resources for the web server.
 type Resources struct {
 	Logger         *slog.Logger
+	Agentic        agentic.Agentic
 	TeamworkEngine interface {
 		Do(context.Context, teamwork.Entity, ...teamwork.Option) error
 	}
@@ -23,6 +25,7 @@ func NewResources(config *Config) *Resources {
 	}))
 	resources := &Resources{
 		Logger:         logger,
+		Agentic:        agentic.Init(config.Agentic.Name, config.Agentic.DSN, logger),
 		TeamworkEngine: teamwork.NewEngine(config.TeamworkServer, config.TeamworkAPIToken, logger),
 	}
 

--- a/internal/mcp/jobrole/resources.go
+++ b/internal/mcp/jobrole/resources.go
@@ -27,6 +27,8 @@ func registerResources(mcpServer *server.MCPServer, configResources *config.Reso
 	mcpServer.AddResource(resourceList,
 		func(ctx context.Context, _ mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
 			var multiple twjobrole.Multiple
+			multiple.Request.Filters.Include = []string{"users"}
+
 			if err := configResources.TeamworkEngine.Do(ctx, &multiple); err != nil {
 				return nil, err
 			}

--- a/internal/mcp/jobrole/tools.go
+++ b/internal/mcp/jobrole/tools.go
@@ -32,6 +32,7 @@ func registerTools(mcpServer *server.MCPServer, configResources *config.Resource
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var multiple twjobrole.Multiple
+			multiple.Request.Filters.Include = []string{"users"}
 
 			err := twmcp.ParamGroup(request.Params.Arguments,
 				twmcp.OptionalParam(&multiple.Request.Filters.SearchTerm, "search-term"),

--- a/internal/mcp/skill/resources.go
+++ b/internal/mcp/skill/resources.go
@@ -27,6 +27,8 @@ func registerResources(mcpServer *server.MCPServer, configResources *config.Reso
 	mcpServer.AddResource(resourceList,
 		func(ctx context.Context, _ mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
 			var multiple twskill.Multiple
+			multiple.Request.Filters.Include = []string{"users"}
+
 			if err := configResources.TeamworkEngine.Do(ctx, &multiple); err != nil {
 				return nil, err
 			}

--- a/internal/mcp/skill/tools.go
+++ b/internal/mcp/skill/tools.go
@@ -31,6 +31,7 @@ func registerTools(mcpServer *server.MCPServer, configResources *config.Resource
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var multiple twskill.Multiple
+			multiple.Request.Filters.Include = []string{"users"}
 
 			err := twmcp.ParamGroup(request.Params.Arguments,
 				twmcp.OptionalParam(&multiple.Request.Filters.SearchTerm, "search-term"),

--- a/internal/teamwork/comment/comment.go
+++ b/internal/teamwork/comment/comment.go
@@ -1,0 +1,255 @@
+// Package comment implements the API layer for managing comments in
+// Teamwork.com. It provides structures and methods for creating, updating,
+// retrieving, and listing comments.
+package comment
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork"
+)
+
+// Comment represents a comment in Teamwork.com. It contains information about
+// the comment's content, the user who posted it, and the associated project and
+// object. The object can be a task, file, milestone, or notebook. The comment
+// also includes metadata such as the date it was posted, edited, or deleted,
+// and the user who performed those actions.
+//
+// More information can be found at:
+// https://support.teamwork.com/projects/getting-started/comments-overview
+type Comment struct {
+	ID          int64  `json:"id"`
+	Body        string `json:"body"`
+	HTMLBody    string `json:"htmlBody"`
+	ContentType string `json:"contentType"`
+
+	Object  *teamwork.Relationship `json:"object"`
+	Project teamwork.Relationship  `json:"project"`
+
+	PostedBy     *int64     `json:"postedBy"`
+	PostedAt     *time.Time `json:"postedDateTime"`
+	LastEditedBy *int64     `json:"lastEditedBy"`
+	EditedAt     *time.Time `json:"dateLastEdited"`
+	Deleted      bool       `json:"deleted"`
+	DeletedBy    *int64     `json:"deletedBy"`
+	DeletedAt    *time.Time `json:"dateDeleted"`
+	WebLink      *string    `json:"webLink,omitempty"`
+}
+
+// PopulateResourceWebLink sets the website URL for the specific resource. It
+// should be called after the object is loaded (the ID is set).
+func (c *Comment) PopulateResourceWebLink(server string) {
+	if c.Object == nil || c.ID == 0 {
+		return
+	}
+	c.WebLink = teamwork.Ref(fmt.Sprintf("https://%s/#%s/%d?c=%d", server, c.Object.Type, c.Object.ID, c.ID))
+}
+
+// Single represents a request to retrieve a single comment by its ID.
+//
+// No public documentation available yet.
+type Single Comment
+
+// HTTPRequest creates an HTTP request to retrieve a single comment by its ID.
+func (s Single) HTTPRequest(ctx context.Context, server string) (*http.Request, error) {
+	uri := fmt.Sprintf("%s/projects/api/v3/comments/%d.json", server, s.ID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	return req, nil
+}
+
+// UnmarshalJSON decodes the JSON data into a Single instance.
+func (s *Single) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Comment Comment `json:"comments"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*s = Single(raw.Comment)
+	return nil
+}
+
+// PopulateResourceWebLink sets the website URL for the specific resource. It
+// should be called after the object is loaded (the ID is set).
+func (s *Single) PopulateResourceWebLink(server string) {
+	(*Comment)(s).PopulateResourceWebLink(server)
+}
+
+// Multiple represents a request to retrieve multiple comments.
+//
+// No public documentation available yet.
+type Multiple struct {
+	Request struct {
+		Path struct {
+			FileID        int64
+			FileVersionID int64
+			MilestoneID   int64
+			NotebookID    int64
+			TaskID        int64
+		}
+		Filters struct {
+			SearchTerm string
+			UserIDs    []int64
+			Page       int64
+			PageSize   int64
+		}
+	}
+	Response struct {
+		Meta struct {
+			Page struct {
+				HasMore bool `json:"hasMore"`
+			} `json:"page"`
+		} `json:"meta"`
+		Comments []Comment `json:"comments"`
+	}
+}
+
+// HTTPRequest creates an HTTP request to retrieve multiple comments.
+func (m Multiple) HTTPRequest(ctx context.Context, server string) (*http.Request, error) {
+	var url string
+	switch {
+	case m.Request.Path.FileID > 0:
+		url = fmt.Sprintf("%s/projects/api/v3/files/%d/comments.json", server, m.Request.Path.FileID)
+	case m.Request.Path.FileVersionID > 0:
+		url = fmt.Sprintf("%s/projects/api/v3/fileversions/%d/comments.json", server, m.Request.Path.FileVersionID)
+	case m.Request.Path.MilestoneID > 0:
+		url = fmt.Sprintf("%s/projects/api/v3/milestones/%d/comments.json", server, m.Request.Path.MilestoneID)
+	case m.Request.Path.NotebookID > 0:
+		url = fmt.Sprintf("%s/projects/api/v3/notebooks/%d/comments.json", server, m.Request.Path.NotebookID)
+	case m.Request.Path.TaskID > 0:
+		url = fmt.Sprintf("%s/projects/api/v3/tasks/%d/comments.json", server, m.Request.Path.TaskID)
+	default:
+		url = fmt.Sprintf("%s/projects/api/v3/comments.json", server)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	query := req.URL.Query()
+	if m.Request.Filters.SearchTerm != "" {
+		query.Set("searchTerm", m.Request.Filters.SearchTerm)
+	}
+	if len(m.Request.Filters.UserIDs) > 0 {
+		userIDs := make([]string, len(m.Request.Filters.UserIDs))
+		for i, id := range m.Request.Filters.UserIDs {
+			userIDs[i] = strconv.FormatInt(id, 10)
+		}
+		query.Set("userIds", strings.Join(userIDs, ","))
+	}
+	if m.Request.Filters.Page > 0 {
+		query.Set("page", strconv.FormatInt(m.Request.Filters.Page, 10))
+	}
+	if m.Request.Filters.PageSize > 0 {
+		query.Set("pageSize", strconv.FormatInt(m.Request.Filters.PageSize, 10))
+	}
+	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
+	return req, nil
+}
+
+// UnmarshalJSON decodes the JSON data into a Multiple instance.
+func (m *Multiple) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &m.Response)
+}
+
+// PopulateResourceWebLink sets the website URL for the specific resource. It
+// should be called after the object is loaded (the ID is set).
+func (m *Multiple) PopulateResourceWebLink(server string) {
+	for i := range m.Response.Comments {
+		m.Response.Comments[i].PopulateResourceWebLink(server)
+	}
+}
+
+// Create represents the payload for creating a new comment in Teamwork.com.
+//
+// https://apidocs.teamwork.com/docs/teamwork/v1/comments/post-resource-resource-id-comments-json
+type Create struct {
+	Object      teamwork.Relationship `json:"-"`
+	Body        string                `json:"body"`
+	ContentType *string               `json:"contentType,omitempty"`
+}
+
+// HTTPRequest creates an HTTP request to create a new comment in a specific
+// entity.
+func (c Create) HTTPRequest(ctx context.Context, server string) (*http.Request, error) {
+	uri := fmt.Sprintf("%s/%s/%d/comments.json", server, c.Object.Type, c.Object.ID)
+	payload := struct {
+		Comment Create `json:"comment"`
+	}{Comment: c}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, uri, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}
+
+// Update represents the payload for updating an existing comment in
+// Teamwork.com.
+//
+// https://apidocs.teamwork.com/docs/teamwork/v1/comments/put-comments-id-json
+type Update struct {
+	ID          int64   `json:"-"`
+	Body        string  `json:"body"`
+	ContentType *string `json:"content-type,omitempty"`
+}
+
+// HTTPRequest creates an HTTP request to update an existing comment in
+// Teamwork.com.
+func (u Update) HTTPRequest(ctx context.Context, server string) (*http.Request, error) {
+	uri := fmt.Sprintf("%s/comments/%d.json", server, u.ID)
+	payload := struct {
+		Comment Update `json:"comment"`
+	}{Comment: u}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, uri, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}
+
+// Delete represents the payload for deleting an existing comment in Teamwork.com.
+//
+// https://apidocs.teamwork.com/docs/teamwork/v1/comments/delete-comments-id-json
+type Delete struct {
+	Request struct {
+		Path struct {
+			ID int64 `json:"-"`
+		}
+	}
+}
+
+// HTTPRequest creates an HTTP request to update a milestone.
+func (d Delete) HTTPRequest(ctx context.Context, server string) (*http.Request, error) {
+	uri := fmt.Sprintf("%s/comments/%d.json", server, d.Request.Path.ID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}

--- a/internal/teamwork/comment/comment_test.go
+++ b/internal/teamwork/comment/comment_test.go
@@ -1,0 +1,441 @@
+package comment_test
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork"
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/comment"
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/project"
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/task"
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/tasklist"
+)
+
+const timeout = 5 * time.Second
+
+var (
+	engine      *teamwork.Engine
+	resourceIDs struct {
+		projectID  int64
+		tasklistID int64
+		taskID     int64
+	}
+)
+
+func TestSingle(t *testing.T) {
+	if engine == nil {
+		t.Skip("Skipping test because the engine is not initialized")
+	}
+
+	create := comment.Create{
+		Object:      teamwork.Relationship{ID: resourceIDs.taskID, Type: "tasks"},
+		Body:        fmt.Sprintf("test%d%d", time.Now().UnixNano(), rand.Intn(100)),
+		ContentType: pointerTo("TEXT"),
+	}
+
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var commentID int64
+	commentIDSetter := teamwork.WithIDCallback("id", func(i int64) {
+		commentID = i
+	})
+	if err := engine.Do(ctx, &create, commentIDSetter); err != nil {
+		t.Fatalf("failed to create comment: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+
+		var commentDelete comment.Delete
+		commentDelete.Request.Path.ID = commentID
+		if err := engine.Do(ctx, &commentDelete); err != nil {
+			t.Logf("⚠️  failed to delete comment: %v", err)
+		}
+	})
+
+	ctx, cancel = context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var single comment.Single
+	single.ID = commentID
+
+	if err := engine.Do(ctx, &single); err != nil {
+		t.Fatalf("failed to get comment: %v", err)
+	}
+	if single.ID != commentID {
+		t.Errorf("expected comment ID %d, got %d", commentID, single.ID)
+	}
+}
+
+func TestMultiple(t *testing.T) {
+	if engine == nil {
+		t.Skip("Skipping test because the engine is not initialized")
+	}
+
+	create := comment.Create{
+		Object:      teamwork.Relationship{ID: resourceIDs.taskID, Type: "tasks"},
+		Body:        fmt.Sprintf("test%d%d", time.Now().UnixNano(), rand.Intn(100)),
+		ContentType: pointerTo("TEXT"),
+	}
+
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var commentID int64
+	commentIDSetter := teamwork.WithIDCallback("id", func(i int64) {
+		commentID = i
+	})
+	if err := engine.Do(ctx, &create, commentIDSetter); err != nil {
+		t.Fatalf("failed to create comment: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+
+		var commentDelete comment.Delete
+		commentDelete.Request.Path.ID = commentID
+		if err := engine.Do(ctx, &commentDelete); err != nil {
+			t.Logf("⚠️  failed to delete comment: %v", err)
+		}
+	})
+
+	tests := []struct {
+		name     string
+		multiple comment.Multiple
+	}{{
+		name: "all comments",
+	}, {
+		name: "comments for task",
+		multiple: func() comment.Multiple {
+			var multiple comment.Multiple
+			multiple.Request.Path.TaskID = resourceIDs.taskID
+			return multiple
+		}(),
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+
+			if err := engine.Do(ctx, &tt.multiple); err != nil {
+				t.Errorf("failed to get comments: %v", err)
+
+			} else if len(tt.multiple.Response.Comments) == 0 {
+				t.Error("expected at least one comment, got none")
+			}
+		})
+	}
+}
+
+func TestCreate(t *testing.T) {
+	if engine == nil {
+		t.Skip("Skipping test because the engine is not initialized")
+	}
+
+	tests := []struct {
+		name   string
+		create comment.Create
+	}{{
+		name: "only required fields",
+		create: comment.Create{
+			Object:      teamwork.Relationship{ID: resourceIDs.taskID, Type: "tasks"},
+			Body:        fmt.Sprintf("test%d%d", time.Now().UnixNano(), rand.Intn(100)),
+			ContentType: pointerTo("TEXT"),
+		},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+
+			var commentID int64
+			commentIDSetter := teamwork.WithIDCallback("id", func(id int64) {
+				commentID = id
+			})
+
+			if err := engine.Do(ctx, &tt.create, commentIDSetter); err != nil {
+				t.Errorf("failed to create comment: %v", err)
+
+			} else {
+				t.Cleanup(func() {
+					ctx := context.Background()
+					ctx, cancel := context.WithTimeout(ctx, timeout)
+					defer cancel()
+
+					var commentDelete comment.Delete
+					commentDelete.Request.Path.ID = commentID
+					if err := engine.Do(ctx, &commentDelete); err != nil {
+						t.Logf("⚠️  failed to delete comment: %v", err)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	if engine == nil {
+		t.Skip("Skipping test because the engine is not initialized")
+	}
+
+	create := comment.Create{
+		Object:      teamwork.Relationship{ID: resourceIDs.taskID, Type: "tasks"},
+		Body:        fmt.Sprintf("test%d%d", time.Now().UnixNano(), rand.Intn(100)),
+		ContentType: pointerTo("TEXT"),
+	}
+
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var commentID int64
+	commentIDSetter := teamwork.WithIDCallback("id", func(i int64) {
+		commentID = i
+	})
+	if err := engine.Do(ctx, &create, commentIDSetter); err != nil {
+		t.Fatalf("failed to create comment: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+
+		var commentDelete comment.Delete
+		commentDelete.Request.Path.ID = commentID
+		if err := engine.Do(ctx, &commentDelete); err != nil {
+			t.Logf("⚠️  failed to delete comment: %v", err)
+		}
+	})
+
+	tests := []struct {
+		name   string
+		create comment.Update
+	}{{
+		name: "all fields",
+		create: comment.Update{
+			ID:          commentID,
+			Body:        "<h1>test</h1>",
+			ContentType: pointerTo("HTML"),
+		},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+
+			if err := engine.Do(ctx, &tt.create); err != nil {
+				t.Errorf("failed to update comment: %v", err)
+			}
+		})
+	}
+}
+
+func createProject(logger *slog.Logger) func() {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	projectCreate := project.Create{
+		Name: fmt.Sprintf("test%d%d", time.Now().UnixNano(), rand.Intn(100)),
+	}
+
+	projectIDSetter := teamwork.WithIDCallback("id", func(id int64) {
+		resourceIDs.projectID = id
+	})
+
+	logger.Info("⚙️ Creating project")
+	if err := engine.Do(ctx, &projectCreate, projectIDSetter); err != nil {
+		logger.Error("failed to create project",
+			slog.String("error", err.Error()),
+		)
+		return func() {}
+	}
+	logger.Info("✅ Created project",
+		slog.Int64("id", resourceIDs.projectID),
+		slog.String("name", projectCreate.Name),
+	)
+
+	return func() {
+		logger.Info("🗑️  Cleaning up project",
+			slog.Int64("id", resourceIDs.projectID),
+		)
+
+		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+
+		var projectDelete project.Delete
+		projectDelete.Request.Path.ID = resourceIDs.projectID
+		if err := engine.Do(ctx, &projectDelete); err != nil {
+			logger.Warn("⚠️  failed to delete project",
+				slog.Int64("id", resourceIDs.projectID),
+				slog.String("error", err.Error()),
+			)
+		}
+	}
+}
+
+func createTasklist(logger *slog.Logger) func() {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	tasklistCreate := tasklist.Create{
+		Name:      fmt.Sprintf("test%d%d", time.Now().UnixNano(), rand.Intn(100)),
+		ProjectID: resourceIDs.projectID,
+	}
+
+	tasklistIDSetter := teamwork.WithIDCallback("tasklistId", func(id int64) {
+		resourceIDs.tasklistID = id
+	})
+
+	logger.Info("⚙️  Creating tasklist")
+	if err := engine.Do(ctx, &tasklistCreate, tasklistIDSetter); err != nil {
+		logger.Error("failed to create tasklist",
+			slog.String("error", err.Error()),
+		)
+		return func() {}
+	}
+	logger.Info("✅ Created tasklist",
+		slog.Int64("id", resourceIDs.tasklistID),
+		slog.String("name", tasklistCreate.Name),
+	)
+
+	return func() {
+		logger.Info("🗑️  Cleaning up tasklist",
+			slog.Int64("id", resourceIDs.tasklistID),
+		)
+
+		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+
+		var tasklistDelete tasklist.Delete
+		tasklistDelete.Request.Path.ID = resourceIDs.tasklistID
+		if err := engine.Do(ctx, &tasklistDelete); err != nil {
+			logger.Warn("⚠️  failed to delete tasklist",
+				slog.Int64("id", resourceIDs.tasklistID),
+				slog.String("error", err.Error()),
+			)
+		}
+	}
+}
+
+func createTask(logger *slog.Logger) func() {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	taskCreate := task.Create{
+		Name:       fmt.Sprintf("test%d%d", time.Now().UnixNano(), rand.Intn(100)),
+		TasklistID: resourceIDs.tasklistID,
+	}
+
+	taskIDSetter := teamwork.WithIDCallback("id", func(id int64) {
+		resourceIDs.taskID = id
+	})
+
+	logger.Info("⚙️  Creating task")
+	if err := engine.Do(ctx, &taskCreate, taskIDSetter); err != nil {
+		logger.Error("failed to create task",
+			slog.String("error", err.Error()),
+		)
+		return func() {}
+	}
+	logger.Info("✅ Created task",
+		slog.Int64("id", resourceIDs.taskID),
+		slog.String("name", taskCreate.Name),
+	)
+
+	return func() {
+		logger.Info("🗑️  Cleaning up task",
+			slog.Int64("id", resourceIDs.taskID),
+		)
+
+		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+
+		var taskDelete task.Delete
+		taskDelete.Request.Path.ID = resourceIDs.taskID
+		if err := engine.Do(ctx, &taskDelete); err != nil {
+			logger.Warn("⚠️  failed to delete task",
+				slog.Int64("id", resourceIDs.taskID),
+				slog.String("error", err.Error()),
+			)
+		}
+	}
+}
+
+func pointerTo[T any](t T) *T {
+	return &t
+}
+
+func startEngine() *teamwork.Engine {
+	server, token := os.Getenv("TWAI_TEAMWORK_SERVER"), os.Getenv("TWAI_TEAMWORK_API_TOKEN")
+	if server == "" || token == "" {
+		return nil
+	}
+	return teamwork.NewEngine(server, token, nil)
+}
+
+func TestMain(m *testing.M) {
+	var exitCode int
+	defer func() {
+		os.Exit(exitCode)
+	}()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{}))
+
+	engine = startEngine()
+	if engine == nil {
+		logger.Info("Missing setup environment variables, skipping tests")
+		return
+	}
+
+	deleteProject := createProject(logger)
+	if resourceIDs.projectID == 0 {
+		exitCode = 1
+		return
+	}
+	defer deleteProject()
+
+	deleteTasklist := createTasklist(logger)
+	if resourceIDs.tasklistID == 0 {
+		exitCode = 1
+		return
+	}
+	defer deleteTasklist()
+
+	deleteTask := createTask(logger)
+	if resourceIDs.taskID == 0 {
+		exitCode = 1
+		return
+	}
+	defer deleteTask()
+
+	reference := time.Now()
+	defer func() {
+		if diff := time.Since(reference); diff < 200*time.Millisecond {
+			time.Sleep(200*time.Millisecond - diff) // ensure tests have enough time to sync
+		}
+	}()
+
+	exitCode = m.Run()
+}

--- a/internal/teamwork/jobrole/jobrole.go
+++ b/internal/teamwork/jobrole/jobrole.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/rafaeljusto/teamwork-ai/internal/teamwork"
@@ -86,6 +87,7 @@ type Multiple struct {
 			SearchTerm string
 			Page       int64
 			PageSize   int64
+			Include    []string
 		}
 	}
 	Response struct {
@@ -114,6 +116,9 @@ func (m Multiple) HTTPRequest(ctx context.Context, server string) (*http.Request
 	}
 	if m.Request.Filters.PageSize > 0 {
 		query.Set("pageSize", strconv.FormatInt(m.Request.Filters.PageSize, 10))
+	}
+	if len(m.Request.Filters.Include) > 0 {
+		query.Set("include", strings.Join(m.Request.Filters.Include, ","))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")

--- a/internal/teamwork/skill/skill.go
+++ b/internal/teamwork/skill/skill.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/rafaeljusto/teamwork-ai/internal/teamwork"
@@ -24,6 +25,8 @@ import (
 type Skill struct {
 	ID   int64  `json:"id"`
 	Name string `json:"name"`
+
+	Users []teamwork.Relationship `json:"users"`
 
 	CreatedByUserID int64      `json:"createdByUser"`
 	CreatedAt       time.Time  `json:"createdAt"`
@@ -86,6 +89,7 @@ type Multiple struct {
 			SearchTerm string
 			Page       int64
 			PageSize   int64
+			Include    []string
 		}
 	}
 	Response struct {
@@ -114,6 +118,9 @@ func (m Multiple) HTTPRequest(ctx context.Context, server string) (*http.Request
 	}
 	if m.Request.Filters.PageSize > 0 {
 		query.Set("pageSize", strconv.FormatInt(m.Request.Filters.PageSize, 10))
+	}
+	if len(m.Request.Filters.Include) > 0 {
+		query.Set("include", strings.Join(m.Request.Filters.Include, ","))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")

--- a/internal/teamwork/types.go
+++ b/internal/teamwork/types.go
@@ -124,6 +124,18 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// UnmarshalText decodes a text string into a Date type. This is required when
+// using Date type as a map key.
+func (d *Date) UnmarshalText(text []byte) error {
+	return d.UnmarshalJSON(text)
+}
+
+// String returns the string representation of the Date in the format
+// "2006-01-02".
+func (d Date) String() string {
+	return time.Time(d).Format("2006-01-02")
+}
+
 // LegacyDate is a type alias for time.Time, used to represent date values in
 // the API.
 type LegacyDate time.Time
@@ -168,4 +180,17 @@ func (n *LegacyNumber) UnmarshalJSON(data []byte) error {
 	}
 	*n = LegacyNumber(parsedInt)
 	return nil
+}
+
+// Money represents a monetary value in the API.
+type Money int64
+
+// Set sets the value of Money from a float64.
+func (m *Money) Set(value float64) {
+	*m = Money(value * 100)
+}
+
+// Value returns the value of Money as a float64.
+func (m Money) Value() float64 {
+	return float64(m) / 100
 }

--- a/internal/teamwork/user/user.go
+++ b/internal/teamwork/user/user.go
@@ -21,13 +21,15 @@ import (
 // is used to manage user information within Teamwork.com, allowing teams to
 // organize and manage their members effectively.
 type User struct {
-	ID        int64   `json:"id"`
-	FirstName string  `json:"firstName"`
-	LastName  string  `json:"lastName"`
-	Title     *string `json:"title"`
-	Email     string  `json:"email"`
-	Admin     bool    `json:"isAdmin"`
-	Type      string  `json:"type"`
+	ID        int64           `json:"id"`
+	FirstName string          `json:"firstName"`
+	LastName  string          `json:"lastName"`
+	Title     *string         `json:"title"`
+	Email     string          `json:"email"`
+	Admin     bool            `json:"isAdmin"`
+	Type      string          `json:"type"`
+	Cost      *teamwork.Money `json:"userCost"`
+	Rate      *teamwork.Money `json:"userRate"`
 
 	Company  teamwork.Relationship   `json:"company"`
 	JobRoles []teamwork.Relationship `json:"jobRoles,omitempty"`

--- a/internal/teamwork/workload/workload.go
+++ b/internal/teamwork/workload/workload.go
@@ -1,0 +1,124 @@
+// Package workload provides functionality to interact with the Teamwork API for
+// managing workloads. It includes structures and methods to retrieve workload
+// information for users, including their capacity and availability.
+package workload
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork"
+)
+
+// Workload represents the response from the API when retrieving a workload. It
+// contains information about users, their capacity, and availability.
+//
+// More information can be found in the Teamwork API documentation:
+// https://support.teamwork.com/projects/workload
+type Workload struct {
+	Users []User `json:"users"`
+}
+
+// User represents a user in the workload response. It contains the user's ID
+// and a map of dates with their corresponding workload information.
+type User struct {
+	ID    int64                      `json:"userId"`
+	Dates map[teamwork.Date]UserDate `json:"dates"`
+}
+
+// UserDate represents the workload information for a specific user on a
+// specific date. It includes the user's capacity, capacity in minutes, and
+// whether the user is unavailable on that date.
+type UserDate struct {
+	Capacity        float64 `json:"capacity"`
+	CapacityMinutes int64   `json:"capacityMinutes"`
+	UnavailableDay  bool    `json:"unavailableDay"`
+}
+
+// Single represents a request to retrieve a workload. You must provide the
+// start and end dates.
+//
+// https://apidocs.teamwork.com/docs/teamwork/endpoints-by-object/workflows/get-projects-api-v3-workflows-json
+type Single struct {
+	Request struct {
+		Filters struct {
+			StartDate teamwork.Date
+			EndDate   teamwork.Date
+			UserIDs   []int64
+			Page      int64
+			PageSize  int64
+			Include   []string
+		}
+	}
+	Response struct {
+		Meta struct {
+			Page struct {
+				HasMore bool `json:"hasMore"`
+			} `json:"page"`
+		} `json:"meta"`
+		Workload Workload `json:"workload"`
+		Included struct {
+			Users map[string]struct {
+				ID          int64                  `json:"id"`
+				LengthOfDay float64                `json:"lengthOfDay"`
+				WorkingHour *teamwork.Relationship `json:"workingHour"`
+			} `json:"users,omitempty"`
+			WorkingHours map[string]struct {
+				ID      int64                   `json:"id"`
+				Object  teamwork.Relationship   `json:"object"`
+				Entries []teamwork.Relationship `json:"entries"`
+			} `json:"workingHours,omitempty"`
+			WorkingHoursEntries map[string]struct {
+				ID          int64                 `json:"id"`
+				WorkingHour teamwork.Relationship `json:"workingHour"`
+				Weekday     string                `json:"weekday"`
+				TaskHours   float64               `json:"taskHours"`
+			} `json:"workingHourEntries,omitempty"`
+		} `json:"included"`
+	}
+}
+
+// HTTPRequest creates an HTTP request to retrieve a single user by their ID.
+func (s Single) HTTPRequest(ctx context.Context, server string) (*http.Request, error) {
+	uri := fmt.Sprintf("%s/projects/api/v3/workload", server)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+	query := req.URL.Query()
+	if !time.Time(s.Request.Filters.StartDate).IsZero() {
+		query.Set("startDate", s.Request.Filters.StartDate.String())
+	}
+	if !time.Time(s.Request.Filters.EndDate).IsZero() {
+		query.Set("endDate", s.Request.Filters.EndDate.String())
+	}
+	if len(s.Request.Filters.UserIDs) > 0 {
+		var ids []string
+		for _, id := range s.Request.Filters.UserIDs {
+			ids = append(ids, strconv.FormatInt(id, 10))
+		}
+		query.Set("userIds", strings.Join(ids, ","))
+	}
+	if s.Request.Filters.Page > 0 {
+		query.Set("page", strconv.FormatInt(s.Request.Filters.Page, 10))
+	}
+	if s.Request.Filters.PageSize > 0 {
+		query.Set("pageSize", strconv.FormatInt(s.Request.Filters.PageSize, 10))
+	}
+	if len(s.Request.Filters.Include) > 0 {
+		query.Set("include", strings.Join(s.Request.Filters.Include, ","))
+	}
+	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
+	return req, nil
+}
+
+// UnmarshalJSON decodes the JSON data into a Single instance.
+func (s *Single) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &s.Response)
+}

--- a/internal/teamwork/workload/workload_test.go
+++ b/internal/teamwork/workload/workload_test.go
@@ -1,0 +1,59 @@
+package workload_test
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork"
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork/workload"
+)
+
+const timeout = 5 * time.Second
+
+var engine *teamwork.Engine
+
+func TestSingle(t *testing.T) {
+	if engine == nil {
+		t.Skip("Skipping test because the engine is not initialized")
+	}
+
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var single workload.Single
+	single.Request.Filters.StartDate = teamwork.Date(time.Now())
+	single.Request.Filters.EndDate = teamwork.Date(time.Now().Add(24 * time.Hour))
+
+	if err := engine.Do(ctx, &single); err != nil {
+		t.Fatalf("failed to get workload: %v", err)
+	}
+}
+
+func startEngine() *teamwork.Engine {
+	server, token := os.Getenv("TWAI_TEAMWORK_SERVER"), os.Getenv("TWAI_TEAMWORK_API_TOKEN")
+	if server == "" || token == "" {
+		return nil
+	}
+	return teamwork.NewEngine(server, token, nil)
+}
+
+func TestMain(m *testing.M) {
+	var exitCode int
+	defer func() {
+		os.Exit(exitCode)
+	}()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{}))
+
+	engine = startEngine()
+	if engine == nil {
+		logger.Info("Missing setup environment variables, skipping tests")
+		return
+	}
+
+	exitCode = m.Run()
+}

--- a/internal/webhook/task.go
+++ b/internal/webhook/task.go
@@ -1,0 +1,28 @@
+package webhook
+
+import "github.com/rafaeljusto/teamwork-ai/internal/teamwork"
+
+// TaskData represents the payload for the task related webhook events in
+// Teamwork.com.
+type TaskData struct {
+	Project struct {
+		ID          int64  `json:"id"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	} `json:"project"`
+	Task struct {
+		ID               int64          `json:"id"`
+		Name             string         `json:"name"`
+		Description      string         `json:"description"`
+		AssignedUserIDs  []int64        `json:"assignedUserIds"`
+		Status           string         `json:"status"`
+		StartDate        *teamwork.Date `json:"startDate"`
+		DueDate          *teamwork.Date `json:"dueDate"`
+		EstimatedMinutes int64          `json:"estimatedMinutes"`
+	} `json:"task"`
+	Tasklist struct {
+		ID          int64  `json:"id"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	} `json:"taskList"`
+}


### PR DESCRIPTION
Introduces a new web server that processes webhook requests from Teamwork.com.

It extracts skills and job roles from incoming tasks and assigns the most suitable users based on matching criteria.

## Related Issue

None.

## Checklist

- [x] I have read the [contributing guidelines](../blob/main/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../blob/main/SECURITY.md).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [cadastros@rafael.net.br](mailto:cadastros@rafael.net.br)) from the maintainers to push the changes.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

None.