### PR TITLE
fix: entities' web links showing prefix twice

### DIFF
--- a/internal/teamwork/comment/comment.go
+++ b/internal/teamwork/comment/comment.go
@@ -49,7 +49,7 @@ func (c *Comment) PopulateResourceWebLink(server string) {
 	if c.Object == nil || c.ID == 0 {
 		return
 	}
-	c.WebLink = teamwork.Ref(fmt.Sprintf("https://%s/#%s/%d?c=%d", server, c.Object.Type, c.Object.ID, c.ID))
+	c.WebLink = teamwork.Ref(fmt.Sprintf("%s/#%s/%d?c=%d", server, c.Object.Type, c.Object.ID, c.ID))
 }
 
 // Single represents a request to retrieve a single comment by its ID.

--- a/internal/teamwork/company/company.go
+++ b/internal/teamwork/company/company.go
@@ -55,7 +55,7 @@ func (c *Company) PopulateResourceWebLink(server string) {
 	if c.ID == 0 {
 		return
 	}
-	c.WebLink = teamwork.Ref(fmt.Sprintf("https://%s/app/clients/%d", server, c.ID))
+	c.WebLink = teamwork.Ref(fmt.Sprintf("%s/app/clients/%d", server, c.ID))
 }
 
 // Single represents a request to retrieve a single company by its ID.

--- a/internal/teamwork/jobrole/jobrole.go
+++ b/internal/teamwork/jobrole/jobrole.go
@@ -41,7 +41,7 @@ func (j *JobRole) PopulateResourceWebLink(server string) {
 	if j.ID == 0 {
 		return
 	}
-	j.WebLink = teamwork.Ref(fmt.Sprintf("https://%s/people/roles", server))
+	j.WebLink = teamwork.Ref(fmt.Sprintf("%s/people/roles", server))
 }
 
 // Single represents a request to retrieve a single job role by its ID.

--- a/internal/teamwork/milestone/milestone.go
+++ b/internal/teamwork/milestone/milestone.go
@@ -45,7 +45,7 @@ func (m *Milestone) PopulateResourceWebLink(server string) {
 	if m.ID == 0 {
 		return
 	}
-	m.WebLink = teamwork.Ref(fmt.Sprintf("https://%s/app/milestones/%d", server, m.ID))
+	m.WebLink = teamwork.Ref(fmt.Sprintf("%s/app/milestones/%d", server, m.ID))
 }
 
 // Single represents a request to retrieve a single milestone by its ID.

--- a/internal/teamwork/project/project.go
+++ b/internal/teamwork/project/project.go
@@ -50,7 +50,7 @@ func (p *Project) PopulateResourceWebLink(server string) {
 	if p.ID == 0 {
 		return
 	}
-	p.WebLink = teamwork.Ref(fmt.Sprintf("https://%s/app/projects/%d", server, p.ID))
+	p.WebLink = teamwork.Ref(fmt.Sprintf("%s/app/projects/%d", server, p.ID))
 }
 
 // Single represents a request to retrieve a single project by its ID.

--- a/internal/teamwork/skill/skill.go
+++ b/internal/teamwork/skill/skill.go
@@ -43,7 +43,7 @@ func (s *Skill) PopulateResourceWebLink(server string) {
 	if s.ID == 0 {
 		return
 	}
-	s.WebLink = teamwork.Ref(fmt.Sprintf("https://%s/app/people/skills", server))
+	s.WebLink = teamwork.Ref(fmt.Sprintf("%s/app/people/skills", server))
 }
 
 // Single represents a request to retrieve a single skill by its ID.

--- a/internal/teamwork/tag/tag.go
+++ b/internal/teamwork/tag/tag.go
@@ -36,7 +36,7 @@ func (t *Tag) PopulateResourceWebLink(server string) {
 	if t.ID == 0 {
 		return
 	}
-	t.WebLink = teamwork.Ref(fmt.Sprintf("https://%s/app/settings/tags", server))
+	t.WebLink = teamwork.Ref(fmt.Sprintf("%s/app/settings/tags", server))
 }
 
 // Single represents a request to retrieve a single tag by its ID.

--- a/internal/teamwork/task/task.go
+++ b/internal/teamwork/task/task.go
@@ -62,7 +62,7 @@ func (t *Task) PopulateResourceWebLink(server string) {
 	if t.ID == 0 {
 		return
 	}
-	t.WebLink = teamwork.Ref(fmt.Sprintf("https://%s/app/tasks/%d", server, t.ID))
+	t.WebLink = teamwork.Ref(fmt.Sprintf("%s/app/tasks/%d", server, t.ID))
 }
 
 // Single represents a request to retrieve a single task by its ID.

--- a/internal/teamwork/tasklist/tasklist.go
+++ b/internal/teamwork/tasklist/tasklist.go
@@ -45,7 +45,7 @@ func (t *Tasklist) PopulateResourceWebLink(server string) {
 	if t.ID == 0 {
 		return
 	}
-	t.WebLink = teamwork.Ref(fmt.Sprintf("https://%s/app/tasklists/%d", server, t.ID))
+	t.WebLink = teamwork.Ref(fmt.Sprintf("%s/app/tasklists/%d", server, t.ID))
 }
 
 // Single represents a request to retrieve a single tasklist by its ID.

--- a/internal/teamwork/user/user.go
+++ b/internal/teamwork/user/user.go
@@ -49,7 +49,7 @@ func (u *User) PopulateResourceWebLink(server string) {
 	if u.ID == 0 {
 		return
 	}
-	u.WebLink = teamwork.Ref(fmt.Sprintf("https://%s/app/people/%d", server, u.ID))
+	u.WebLink = teamwork.Ref(fmt.Sprintf("%s/app/people/%d", server, u.ID))
 }
 
 // Single represents a request to retrieve a single user by their ID.


### PR DESCRIPTION
The web links were showing the protocol twice like:
```
https://https://example.com
```

This was happening because the injected variable already have the prefix.

## Related Issue

None.

## Checklist

- [x] I have read the [contributing guidelines](../blob/main/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../blob/main/SECURITY.md).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [cadastros@rafael.net.br](mailto:cadastros@rafael.net.br)) from the maintainers to push the changes.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

None.