### PR TITLE
feat(mcp): add support for comments

### DIFF
--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/rafaeljusto/teamwork-ai/internal/config"
+	mcpcomment "github.com/rafaeljusto/teamwork-ai/internal/mcp/comment"
 	mcpcompany "github.com/rafaeljusto/teamwork-ai/internal/mcp/company"
 	mcpindustry "github.com/rafaeljusto/teamwork-ai/internal/mcp/industry"
 	mcpjobrole "github.com/rafaeljusto/teamwork-ai/internal/mcp/jobrole"
@@ -120,6 +121,7 @@ func newMCPServer(resources *config.Resources) *server.MCPServer {
 	mcptag.Register(mcpServer, resources)
 	mcpmilestone.Register(mcpServer, resources)
 	mcpjobrole.Register(mcpServer, resources)
+	mcpcomment.Register(mcpServer, resources)
 
 	return mcpServer
 }

--- a/internal/mcp/comment/comment.go
+++ b/internal/mcp/comment/comment.go
@@ -1,0 +1,15 @@
+package comment
+
+import (
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/rafaeljusto/teamwork-ai/internal/config"
+)
+
+// Register registers the comment resources and tools with the MCP server. It
+// provides functionality to retrieve, create, and manage comments in a customer
+// site of Teamwork.com. Comments are messages or notes that can be added to
+// various objects in Teamwork, such as tasks, files, milestones, and notebooks.
+func Register(mcpServer *server.MCPServer, configResources *config.Resources) {
+	registerResources(mcpServer, configResources)
+	registerTools(mcpServer, configResources)
+}

--- a/internal/mcp/comment/docs.go
+++ b/internal/mcp/comment/docs.go
@@ -1,0 +1,5 @@
+// Package comment provides the implementation of the Model Context Protocol
+// (MCP) for managing comments in Teamwork.com. It allows for the retrieval and
+// management of comments associated with various objects in Teamwork, such as
+// tasks, files, milestones, and notebooks.
+package comment

--- a/internal/mcp/comment/resources.go
+++ b/internal/mcp/comment/resources.go
@@ -1,0 +1,82 @@
+package comment
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/rafaeljusto/teamwork-ai/internal/config"
+	twcomment "github.com/rafaeljusto/teamwork-ai/internal/teamwork/comment"
+)
+
+var resourceList = mcp.NewResource("twapi://comments", "comments",
+	mcp.WithResourceDescription("Comments are messages or notes that can be added to various "+
+		"objects in Teamwork, such as tasks, files, milestones, and notebooks."),
+	mcp.WithMIMEType("application/json"),
+)
+
+var resourceItem = mcp.NewResourceTemplate("twapi://comments/{id}", "comment",
+	mcp.WithTemplateDescription("Comment is a message or note that can be added to various "+
+		"objects in Teamwork, such as tasks, files, milestones, and notebooks."),
+	mcp.WithTemplateMIMEType("application/json"),
+)
+
+func registerResources(mcpServer *server.MCPServer, configResources *config.Resources) {
+	mcpServer.AddResource(resourceList,
+		func(ctx context.Context, _ mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+			var multiple twcomment.Multiple
+			if err := configResources.TeamworkEngine.Do(ctx, &multiple); err != nil {
+				return nil, err
+			}
+			var resourceContents []mcp.ResourceContents
+			for _, comment := range multiple.Response.Comments {
+				encoded, err := json.Marshal(comment)
+				if err != nil {
+					return nil, err
+				}
+				resourceContents = append(resourceContents, mcp.TextResourceContents{
+					URI:      fmt.Sprintf("twapi://comments/%d", comment.ID),
+					MIMEType: "application/json",
+					Text:     string(encoded),
+				})
+			}
+			return resourceContents, nil
+		},
+	)
+
+	reCommentID := regexp.MustCompile(`twapi://comments/(\d+)`)
+	mcpServer.AddResourceTemplate(resourceItem,
+		func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+			matches := reCommentID.FindStringSubmatch(request.Params.URI)
+			if len(matches) != 2 {
+				return nil, fmt.Errorf("invalid comment ID")
+			}
+			commentID, err := strconv.ParseInt(matches[1], 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid comment ID")
+			}
+
+			var comment twcomment.Single
+			comment.ID = commentID
+			if err := configResources.TeamworkEngine.Do(ctx, &comment); err != nil {
+				return nil, err
+			}
+
+			encoded, err := json.Marshal(comment)
+			if err != nil {
+				return nil, err
+			}
+			return []mcp.ResourceContents{
+				mcp.TextResourceContents{
+					URI:      fmt.Sprintf("twapi://comments/%d", comment.ID),
+					MIMEType: "application/json",
+					Text:     string(encoded),
+				},
+			}, nil
+		},
+	)
+}

--- a/internal/mcp/comment/resources_test.go
+++ b/internal/mcp/comment/resources_test.go
@@ -1,0 +1,77 @@
+package comment_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/rafaeljusto/teamwork-ai/internal/config"
+	"github.com/rafaeljusto/teamwork-ai/internal/mcp/comment"
+)
+
+func TestResources_comments(t *testing.T) {
+	mcpServer := server.NewMCPServer("test-server", "1.0.0")
+	comment.Register(mcpServer, &config.Resources{
+		TeamworkEngine: engineMock{},
+	})
+
+	request := &resourceRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      1,
+		ReadResourceRequest: mcp.ReadResourceRequest{
+			Request: mcp.Request{
+				Method: string(mcp.MethodResourcesRead),
+			},
+		},
+	}
+	request.Params.URI = "twapi://comments"
+
+	encodedRequest, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("failed to encode request: %v", err)
+	}
+
+	ctx := context.Background()
+	message := mcpServer.HandleMessage(ctx, encodedRequest)
+	if err, ok := message.(mcp.JSONRPCError); ok {
+		t.Errorf("tool failed to execute: %v", err.Error)
+	}
+}
+
+func TestResources_comment(t *testing.T) {
+	mcpServer := server.NewMCPServer("test-server", "1.0.0")
+	comment.Register(mcpServer, &config.Resources{
+		TeamworkEngine: engineMock{},
+	})
+
+	request := &resourceRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      1,
+		ReadResourceRequest: mcp.ReadResourceRequest{
+			Request: mcp.Request{
+				Method: string(mcp.MethodResourcesRead),
+			},
+		},
+	}
+	request.Params.URI = "twapi://comments/123"
+
+	encodedRequest, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("failed to encode request: %v", err)
+	}
+
+	ctx := context.Background()
+	message := mcpServer.HandleMessage(ctx, encodedRequest)
+	if err, ok := message.(mcp.JSONRPCError); ok {
+		t.Errorf("tool failed to execute: %v", err.Error)
+	}
+}
+
+type resourceRequest struct {
+	mcp.ReadResourceRequest
+
+	JSONRPC string `json:"jsonrpc"`
+	ID      int64  `json:"id"`
+}

--- a/internal/mcp/comment/tools.go
+++ b/internal/mcp/comment/tools.go
@@ -1,0 +1,390 @@
+package comment
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/rafaeljusto/teamwork-ai/internal/config"
+	twmcp "github.com/rafaeljusto/teamwork-ai/internal/mcp"
+	twcomment "github.com/rafaeljusto/teamwork-ai/internal/teamwork/comment"
+)
+
+func registerTools(mcpServer *server.MCPServer, configResources *config.Resources) {
+	mcpServer.AddTool(
+		mcp.NewTool("retrieve-comments",
+			mcp.WithDescription("Retrieve multiple comments in a customer site of Teamwork.com. "+
+				"Within Teamwork.com, you can comment on project items such as tasks, milestones, files and notebooks."),
+			mcp.WithString("search-term",
+				mcp.Description("A search term to filter comments by the content, also know as body in the response. "+
+					"Each word from the search term is used to match against the comment content."),
+			),
+			mcp.WithArray("user-ids",
+				mcp.Description("A list of user IDs to filter comments by who posted them."),
+				mcp.Items(map[string]any{
+					"type": "number",
+				}),
+			),
+			mcp.WithNumber("page",
+				mcp.Description("Page number for pagination of results."),
+			),
+			mcp.WithNumber("page-size",
+				mcp.Description("Number of results per page for pagination."),
+			),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			var multiple twcomment.Multiple
+
+			err := twmcp.ParamGroup(request.Params.Arguments,
+				twmcp.OptionalParam(&multiple.Request.Filters.SearchTerm, "search-term"),
+				twmcp.OptionalNumericListParam(&multiple.Request.Filters.UserIDs, "user-ids"),
+				twmcp.OptionalNumericParam(&multiple.Request.Filters.Page, "page"),
+				twmcp.OptionalNumericParam(&multiple.Request.Filters.PageSize, "page-size"),
+			)
+			if err != nil {
+				return nil, fmt.Errorf("invalid parameters: %w", err)
+			}
+
+			if err := configResources.TeamworkEngine.Do(ctx, &multiple); err != nil {
+				return nil, err
+			}
+			encoded, err := json.Marshal(multiple.Response)
+			if err != nil {
+				return nil, err
+			}
+			return mcp.NewToolResultText(string(encoded)), nil
+		},
+	)
+
+	mcpServer.AddTool(
+		mcp.NewTool("retrieve-file-comments",
+			mcp.WithDescription("Retrieve multiple comments from a file in a customer site of Teamwork.com. "+
+				"Within Teamwork.com, you can comment on project items such as tasks, milestones, files and notebooks."),
+			mcp.WithNumber("file-id",
+				mcp.Required(),
+				mcp.Description("The ID of the file to retrieve comments from."),
+			),
+			mcp.WithString("search-term",
+				mcp.Description("A search term to filter comments by the content, also know as body in the response. "+
+					"Each word from the search term is used to match against the comment content."),
+			),
+			mcp.WithArray("user-ids",
+				mcp.Description("A list of user IDs to filter comments by who posted them."),
+				mcp.Items(map[string]any{
+					"type": "number",
+				}),
+			),
+			mcp.WithNumber("page",
+				mcp.Description("Page number for pagination of results."),
+			),
+			mcp.WithNumber("page-size",
+				mcp.Description("Number of results per page for pagination."),
+			),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			var multiple twcomment.Multiple
+
+			err := twmcp.ParamGroup(request.Params.Arguments,
+				twmcp.RequiredNumericParam(&multiple.Request.Path.FileID, "file-id"),
+				twmcp.OptionalParam(&multiple.Request.Filters.SearchTerm, "search-term"),
+				twmcp.OptionalNumericListParam(&multiple.Request.Filters.UserIDs, "user-ids"),
+				twmcp.OptionalNumericParam(&multiple.Request.Filters.Page, "page"),
+				twmcp.OptionalNumericParam(&multiple.Request.Filters.PageSize, "page-size"),
+			)
+			if err != nil {
+				return nil, fmt.Errorf("invalid parameters: %w", err)
+			}
+
+			if err := configResources.TeamworkEngine.Do(ctx, &multiple); err != nil {
+				return nil, err
+			}
+			encoded, err := json.Marshal(multiple.Response)
+			if err != nil {
+				return nil, err
+			}
+			return mcp.NewToolResultText(string(encoded)), nil
+		},
+	)
+
+	mcpServer.AddTool(
+		mcp.NewTool("retrieve-milestone-comments",
+			mcp.WithDescription("Retrieve multiple comments from a milestone in a customer site of Teamwork.com. "+
+				"Within Teamwork.com, you can comment on project items such as tasks, milestones, files and notebooks."),
+			mcp.WithNumber("milestone-id",
+				mcp.Required(),
+				mcp.Description("The ID of the milestone to retrieve comments from."),
+			),
+			mcp.WithString("search-term",
+				mcp.Description("A search term to filter comments by the content, also know as body in the response. "+
+					"Each word from the search term is used to match against the comment content."),
+			),
+			mcp.WithArray("user-ids",
+				mcp.Description("A list of user IDs to filter comments by who posted them."),
+				mcp.Items(map[string]any{
+					"type": "number",
+				}),
+			),
+			mcp.WithNumber("page",
+				mcp.Description("Page number for pagination of results."),
+			),
+			mcp.WithNumber("page-size",
+				mcp.Description("Number of results per page for pagination."),
+			),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			var multiple twcomment.Multiple
+
+			err := twmcp.ParamGroup(request.Params.Arguments,
+				twmcp.RequiredNumericParam(&multiple.Request.Path.MilestoneID, "milestone-id"),
+				twmcp.OptionalParam(&multiple.Request.Filters.SearchTerm, "search-term"),
+				twmcp.OptionalNumericListParam(&multiple.Request.Filters.UserIDs, "user-ids"),
+				twmcp.OptionalNumericParam(&multiple.Request.Filters.Page, "page"),
+				twmcp.OptionalNumericParam(&multiple.Request.Filters.PageSize, "page-size"),
+			)
+			if err != nil {
+				return nil, fmt.Errorf("invalid parameters: %w", err)
+			}
+
+			if err := configResources.TeamworkEngine.Do(ctx, &multiple); err != nil {
+				return nil, err
+			}
+			encoded, err := json.Marshal(multiple.Response)
+			if err != nil {
+				return nil, err
+			}
+			return mcp.NewToolResultText(string(encoded)), nil
+		},
+	)
+
+	mcpServer.AddTool(
+		mcp.NewTool("retrieve-notebook-comments",
+			mcp.WithDescription("Retrieve multiple comments from a notebook in a customer site of Teamwork.com. "+
+				"Within Teamwork.com, you can comment on project items such as tasks, notebooks, files and notebooks."),
+			mcp.WithNumber("notebook-id",
+				mcp.Required(),
+				mcp.Description("The ID of the notebook to retrieve comments from."),
+			),
+			mcp.WithString("search-term",
+				mcp.Description("A search term to filter comments by the content, also know as body in the response. "+
+					"Each word from the search term is used to match against the comment content."),
+			),
+			mcp.WithArray("user-ids",
+				mcp.Description("A list of user IDs to filter comments by who posted them."),
+				mcp.Items(map[string]any{
+					"type": "number",
+				}),
+			),
+			mcp.WithNumber("page",
+				mcp.Description("Page number for pagination of results."),
+			),
+			mcp.WithNumber("page-size",
+				mcp.Description("Number of results per page for pagination."),
+			),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			var multiple twcomment.Multiple
+
+			err := twmcp.ParamGroup(request.Params.Arguments,
+				twmcp.RequiredNumericParam(&multiple.Request.Path.NotebookID, "notebook-id"),
+				twmcp.OptionalParam(&multiple.Request.Filters.SearchTerm, "search-term"),
+				twmcp.OptionalNumericListParam(&multiple.Request.Filters.UserIDs, "user-ids"),
+				twmcp.OptionalNumericParam(&multiple.Request.Filters.Page, "page"),
+				twmcp.OptionalNumericParam(&multiple.Request.Filters.PageSize, "page-size"),
+			)
+			if err != nil {
+				return nil, fmt.Errorf("invalid parameters: %w", err)
+			}
+
+			if err := configResources.TeamworkEngine.Do(ctx, &multiple); err != nil {
+				return nil, err
+			}
+			encoded, err := json.Marshal(multiple.Response)
+			if err != nil {
+				return nil, err
+			}
+			return mcp.NewToolResultText(string(encoded)), nil
+		},
+	)
+
+	mcpServer.AddTool(
+		mcp.NewTool("retrieve-task-comments",
+			mcp.WithDescription("Retrieve multiple comments from a task in a customer site of Teamwork.com. "+
+				"Within Teamwork.com, you can comment on project items such as tasks, milestones, files and notebooks."),
+			mcp.WithNumber("task-id",
+				mcp.Required(),
+				mcp.Description("The ID of the task to retrieve comments from."),
+			),
+			mcp.WithString("search-term",
+				mcp.Description("A search term to filter comments by the content, also know as body in the response. "+
+					"Each word from the search term is used to match against the comment content."),
+			),
+			mcp.WithArray("user-ids",
+				mcp.Description("A list of user IDs to filter comments by who posted them."),
+				mcp.Items(map[string]any{
+					"type": "number",
+				}),
+			),
+			mcp.WithNumber("page",
+				mcp.Description("Page number for pagination of results."),
+			),
+			mcp.WithNumber("page-size",
+				mcp.Description("Number of results per page for pagination."),
+			),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			var multiple twcomment.Multiple
+
+			err := twmcp.ParamGroup(request.Params.Arguments,
+				twmcp.RequiredNumericParam(&multiple.Request.Path.TaskID, "task-id"),
+				twmcp.OptionalParam(&multiple.Request.Filters.SearchTerm, "search-term"),
+				twmcp.OptionalNumericListParam(&multiple.Request.Filters.UserIDs, "user-ids"),
+				twmcp.OptionalNumericParam(&multiple.Request.Filters.Page, "page"),
+				twmcp.OptionalNumericParam(&multiple.Request.Filters.PageSize, "page-size"),
+			)
+			if err != nil {
+				return nil, fmt.Errorf("invalid parameters: %w", err)
+			}
+
+			if err := configResources.TeamworkEngine.Do(ctx, &multiple); err != nil {
+				return nil, err
+			}
+			encoded, err := json.Marshal(multiple.Response)
+			if err != nil {
+				return nil, err
+			}
+			return mcp.NewToolResultText(string(encoded)), nil
+		},
+	)
+
+	mcpServer.AddTool(
+		mcp.NewTool("retrieve-comment",
+			mcp.WithDescription("Retrieve a specific comment in a customer site of Teamwork.com. "+
+				"Within Teamwork.com, you can comment on project items such as tasks, milestones, files and notebooks."),
+			mcp.WithNumber("comment-id",
+				mcp.Required(),
+				mcp.Description("The ID of the comment."),
+			),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			var single twcomment.Single
+
+			err := twmcp.ParamGroup(request.Params.Arguments,
+				twmcp.RequiredNumericParam(&single.ID, "comment-id"),
+			)
+			if err != nil {
+				return nil, fmt.Errorf("invalid parameters: %w", err)
+			}
+
+			if err := configResources.TeamworkEngine.Do(ctx, &single); err != nil {
+				return nil, err
+			}
+			encoded, err := json.Marshal(single)
+			if err != nil {
+				return nil, err
+			}
+			return mcp.NewToolResultText(string(encoded)), nil
+		},
+	)
+
+	mcpServer.AddTool(
+		mcp.NewTool("create-comment",
+			mcp.WithDescription("Create a new comment in a customer site of Teamwork.com. "+
+				"Within Teamwork.com, you can comment on project items such as tasks, milestones, files and notebooks."),
+			mcp.WithObject("object",
+				mcp.Required(),
+				mcp.Description("The object to create the comment for. "+
+					"It can be a tasks, messages, milestones, files or notebooks."),
+				mcp.Properties(map[string]any{
+					"type": map[string]any{
+						"type": "string",
+						"enum": []string{"tasks", "messages", "milestones", "files", "notebooks"},
+						"description": "The type of object to create the comment for. " +
+							"It can be a tasks, messages, milestones, files or notebooks.",
+					},
+					"id": map[string]any{
+						"type":        "number",
+						"description": "The ID of the object to create the comment for.",
+					},
+				}),
+			),
+			mcp.WithString("body",
+				mcp.Required(),
+				mcp.Description("The content of the comment. The content can be added as text or HTML."),
+			),
+			mcp.WithString("content-type",
+				mcp.Description("The content type of the comment. It can be either 'TEXT' or 'HTML'."),
+			),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			var comment twcomment.Create
+
+			err := twmcp.ParamGroup(request.Params.Arguments,
+				twmcp.RequiredParam(&comment.Body, "body"),
+				twmcp.OptionalPointerParam(&comment.ContentType, "content-type"),
+			)
+			if err != nil {
+				return nil, fmt.Errorf("invalid parameters: %w", err)
+			}
+
+			object, ok := request.Params.Arguments["object"]
+			if !ok {
+				return nil, fmt.Errorf("missing required parameter: object")
+			}
+			objectMap, ok := object.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("invalid object: expected an object, got %T", object)
+			} else if objectMap == nil {
+				return nil, fmt.Errorf("object cannot be nil")
+			}
+			err = twmcp.ParamGroup(objectMap,
+				twmcp.RequiredParam(&comment.Object.Type, "type"),
+				twmcp.RequiredNumericParam(&comment.Object.ID, "id"),
+			)
+			if err != nil {
+				return nil, fmt.Errorf("invalid object: %w", err)
+			}
+
+			if err := configResources.TeamworkEngine.Do(ctx, &comment); err != nil {
+				return nil, err
+			}
+			return mcp.NewToolResultText("Comment created successfully"), nil
+		},
+	)
+
+	mcpServer.AddTool(
+		mcp.NewTool("update-comment",
+			mcp.WithDescription("Update a comment in a customer site of Teamwork.com. "+
+				"Within Teamwork.com, you can comment on project items such as tasks, milestones, files and notebooks."),
+			mcp.WithNumber("comment-id",
+				mcp.Required(),
+				mcp.Description("The ID of the comment to update."),
+			),
+			mcp.WithString("body",
+				mcp.Required(),
+				mcp.Description("The content of the comment. The content can be added as text or HTML."),
+			),
+			mcp.WithString("content-type",
+				mcp.Description("The content type of the comment. It can be either 'TEXT' or 'HTML'."),
+			),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			var comment twcomment.Update
+
+			err := twmcp.ParamGroup(request.Params.Arguments,
+				twmcp.RequiredNumericParam(&comment.ID, "comment-id"),
+				twmcp.RequiredParam(&comment.Body, "body"),
+				twmcp.OptionalPointerParam(&comment.ContentType, "content-type"),
+			)
+			if err != nil {
+				return nil, fmt.Errorf("invalid parameters: %w", err)
+			}
+
+			if err := configResources.TeamworkEngine.Do(ctx, &comment); err != nil {
+				return nil, err
+			}
+			return mcp.NewToolResultText("Comment updated successfully"), nil
+		},
+	)
+}

--- a/internal/mcp/comment/tools_test.go
+++ b/internal/mcp/comment/tools_test.go
@@ -1,0 +1,309 @@
+package comment_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/rafaeljusto/teamwork-ai/internal/config"
+	"github.com/rafaeljusto/teamwork-ai/internal/mcp/comment"
+	"github.com/rafaeljusto/teamwork-ai/internal/teamwork"
+)
+
+func TestTools_retrieveComments(t *testing.T) {
+	mcpServer := server.NewMCPServer("test-server", "1.0.0")
+	comment.Register(mcpServer, &config.Resources{
+		TeamworkEngine: engineMock{},
+	})
+
+	request := &toolRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      1,
+		CallToolRequest: mcp.CallToolRequest{
+			Request: mcp.Request{
+				Method: string(mcp.MethodToolsCall),
+			},
+		},
+	}
+	request.Params.Name = "retrieve-comments"
+	request.Params.Arguments = map[string]any{
+		"search-term": "test",
+		"user-ids":    []float64{1, 2, 3},
+		"page":        float64(1),
+		"page-size":   float64(10),
+	}
+
+	encodedRequest, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("failed to encode request: %v", err)
+	}
+
+	ctx := context.Background()
+	message := mcpServer.HandleMessage(ctx, encodedRequest)
+	if err, ok := message.(mcp.JSONRPCError); ok {
+		t.Errorf("tool failed to execute: %v", err.Error)
+	}
+}
+
+func TestTools_retrieveFileComments(t *testing.T) {
+	mcpServer := server.NewMCPServer("test-server", "1.0.0")
+	comment.Register(mcpServer, &config.Resources{
+		TeamworkEngine: engineMock{},
+	})
+
+	request := &toolRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      1,
+		CallToolRequest: mcp.CallToolRequest{
+			Request: mcp.Request{
+				Method: string(mcp.MethodToolsCall),
+			},
+		},
+	}
+	request.Params.Name = "retrieve-file-comments"
+	request.Params.Arguments = map[string]any{
+		"file-id":     float64(123),
+		"search-term": "test",
+		"user-ids":    []float64{1, 2, 3},
+		"page":        float64(1),
+		"page-size":   float64(10),
+	}
+
+	encodedRequest, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("failed to encode request: %v", err)
+	}
+
+	ctx := context.Background()
+	message := mcpServer.HandleMessage(ctx, encodedRequest)
+	if err, ok := message.(mcp.JSONRPCError); ok {
+		t.Errorf("tool failed to execute: %v", err.Error)
+	}
+}
+
+func TestTools_retrieveMilestoneComments(t *testing.T) {
+	mcpServer := server.NewMCPServer("test-server", "1.0.0")
+	comment.Register(mcpServer, &config.Resources{
+		TeamworkEngine: engineMock{},
+	})
+
+	request := &toolRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      1,
+		CallToolRequest: mcp.CallToolRequest{
+			Request: mcp.Request{
+				Method: string(mcp.MethodToolsCall),
+			},
+		},
+	}
+	request.Params.Name = "retrieve-milestone-comments"
+	request.Params.Arguments = map[string]any{
+		"milestone-id": float64(123),
+		"search-term":  "test",
+		"user-ids":     []float64{1, 2, 3},
+		"page":         float64(1),
+		"page-size":    float64(10),
+	}
+
+	encodedRequest, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("failed to encode request: %v", err)
+	}
+
+	ctx := context.Background()
+	message := mcpServer.HandleMessage(ctx, encodedRequest)
+	if err, ok := message.(mcp.JSONRPCError); ok {
+		t.Errorf("tool failed to execute: %v", err.Error)
+	}
+}
+
+func TestTools_retrieveNotebookComments(t *testing.T) {
+	mcpServer := server.NewMCPServer("test-server", "1.0.0")
+	comment.Register(mcpServer, &config.Resources{
+		TeamworkEngine: engineMock{},
+	})
+
+	request := &toolRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      1,
+		CallToolRequest: mcp.CallToolRequest{
+			Request: mcp.Request{
+				Method: string(mcp.MethodToolsCall),
+			},
+		},
+	}
+	request.Params.Name = "retrieve-notebook-comments"
+	request.Params.Arguments = map[string]any{
+		"notebook-id": float64(123),
+		"search-term": "test",
+		"user-ids":    []float64{1, 2, 3},
+		"page":        float64(1),
+		"page-size":   float64(10),
+	}
+
+	encodedRequest, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("failed to encode request: %v", err)
+	}
+
+	ctx := context.Background()
+	message := mcpServer.HandleMessage(ctx, encodedRequest)
+	if err, ok := message.(mcp.JSONRPCError); ok {
+		t.Errorf("tool failed to execute: %v", err.Error)
+	}
+}
+
+func TestTools_retrieveTaskComments(t *testing.T) {
+	mcpServer := server.NewMCPServer("test-server", "1.0.0")
+	comment.Register(mcpServer, &config.Resources{
+		TeamworkEngine: engineMock{},
+	})
+
+	request := &toolRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      1,
+		CallToolRequest: mcp.CallToolRequest{
+			Request: mcp.Request{
+				Method: string(mcp.MethodToolsCall),
+			},
+		},
+	}
+	request.Params.Name = "retrieve-task-comments"
+	request.Params.Arguments = map[string]any{
+		"task-id":     float64(123),
+		"search-term": "test",
+		"user-ids":    []float64{1, 2, 3},
+		"page":        float64(1),
+		"page-size":   float64(10),
+	}
+
+	encodedRequest, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("failed to encode request: %v", err)
+	}
+
+	ctx := context.Background()
+	message := mcpServer.HandleMessage(ctx, encodedRequest)
+	if err, ok := message.(mcp.JSONRPCError); ok {
+		t.Errorf("tool failed to execute: %v", err.Error)
+	}
+}
+
+func TestTools_retrieveComment(t *testing.T) {
+	mcpServer := server.NewMCPServer("test-server", "1.0.0")
+	comment.Register(mcpServer, &config.Resources{
+		TeamworkEngine: engineMock{},
+	})
+
+	request := &toolRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      1,
+		CallToolRequest: mcp.CallToolRequest{
+			Request: mcp.Request{
+				Method: string(mcp.MethodToolsCall),
+			},
+		},
+	}
+	request.Params.Name = "retrieve-comment"
+	request.Params.Arguments = map[string]any{
+		"comment-id": float64(123),
+	}
+
+	encodedRequest, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("failed to encode request: %v", err)
+	}
+
+	ctx := context.Background()
+	message := mcpServer.HandleMessage(ctx, encodedRequest)
+	if err, ok := message.(mcp.JSONRPCError); ok {
+		t.Errorf("tool failed to execute: %v", err.Error)
+	}
+}
+
+func TestTools_createComment(t *testing.T) {
+	mcpServer := server.NewMCPServer("test-server", "1.0.0")
+	comment.Register(mcpServer, &config.Resources{
+		TeamworkEngine: engineMock{},
+	})
+
+	request := &toolRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      1,
+		CallToolRequest: mcp.CallToolRequest{
+			Request: mcp.Request{
+				Method: string(mcp.MethodToolsCall),
+			},
+		},
+	}
+	request.Params.Name = "create-comment"
+	request.Params.Arguments = map[string]any{
+		"object": map[string]any{
+			"type": "tasks",
+			"id":   float64(123),
+		},
+		"body":         "Example",
+		"content-type": "TEXT",
+	}
+
+	encodedRequest, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("failed to encode request: %v", err)
+	}
+
+	ctx := context.Background()
+	message := mcpServer.HandleMessage(ctx, encodedRequest)
+	if err, ok := message.(mcp.JSONRPCError); ok {
+		t.Errorf("tool failed to execute: %v", err.Error)
+	}
+}
+
+func TestTools_updateComment(t *testing.T) {
+	mcpServer := server.NewMCPServer("test-server", "1.0.0")
+	comment.Register(mcpServer, &config.Resources{
+		TeamworkEngine: engineMock{},
+	})
+
+	request := &toolRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      1,
+		CallToolRequest: mcp.CallToolRequest{
+			Request: mcp.Request{
+				Method: string(mcp.MethodToolsCall),
+			},
+		},
+	}
+	request.Params.Name = "update-comment"
+	request.Params.Arguments = map[string]any{
+		"comment-id":   float64(123),
+		"body":         "Example",
+		"content-type": "TEXT",
+	}
+
+	encodedRequest, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("failed to encode request: %v", err)
+	}
+
+	ctx := context.Background()
+	message := mcpServer.HandleMessage(ctx, encodedRequest)
+	if err, ok := message.(mcp.JSONRPCError); ok {
+		t.Errorf("tool failed to execute: %v", err.Error)
+	}
+}
+
+type toolRequest struct {
+	mcp.CallToolRequest
+
+	JSONRPC string `json:"jsonrpc"`
+	ID      int64  `json:"id"`
+}
+
+type engineMock struct {
+}
+
+func (e engineMock) Do(context.Context, teamwork.Entity, ...teamwork.Option) error {
+	return nil
+}


### PR DESCRIPTION
Allow comments management in the Teamwork.com account via the MCP server.

## Related Issue

None.

## Checklist

- [ ] I have read the [contributing guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../blob/main/SECURITY.md).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [cadastros@rafael.net.br](mailto:cadastros@rafael.net.br)) from the maintainers to push the changes.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

None.