### PR TITLE
fix(mcp): restrict the amount of data in the response

### DIFF
--- a/internal/mcp/skill/tools.go
+++ b/internal/mcp/skill/tools.go
@@ -45,7 +45,7 @@ func registerTools(mcpServer *server.MCPServer, configResources *config.Resource
 			if err := configResources.TeamworkEngine.Do(ctx, &multiple); err != nil {
 				return nil, err
 			}
-			encoded, err := json.Marshal(multiple)
+			encoded, err := json.Marshal(multiple.Response)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/mcp/task/tools.go
+++ b/internal/mcp/task/tools.go
@@ -64,7 +64,7 @@ func registerToolsRetrieve(mcpServer *server.MCPServer, configResources *config.
 			if err := configResources.TeamworkEngine.Do(ctx, &multiple); err != nil {
 				return nil, err
 			}
-			encoded, err := json.Marshal(multiple)
+			encoded, err := json.Marshal(multiple.Response)
 			if err != nil {
 				return nil, err
 			}
@@ -121,7 +121,7 @@ func registerToolsRetrieve(mcpServer *server.MCPServer, configResources *config.
 			if err := configResources.TeamworkEngine.Do(ctx, &multiple); err != nil {
 				return nil, err
 			}
-			encoded, err := json.Marshal(multiple)
+			encoded, err := json.Marshal(multiple.Response)
 			if err != nil {
 				return nil, err
 			}
@@ -178,7 +178,7 @@ func registerToolsRetrieve(mcpServer *server.MCPServer, configResources *config.
 			if err := configResources.TeamworkEngine.Do(ctx, &multiple); err != nil {
 				return nil, err
 			}
-			encoded, err := json.Marshal(multiple)
+			encoded, err := json.Marshal(multiple.Response)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/mcp/tasklist/tools.go
+++ b/internal/mcp/tasklist/tools.go
@@ -42,7 +42,7 @@ func registerTools(mcpServer *server.MCPServer, configResources *config.Resource
 			if err := configResources.TeamworkEngine.Do(ctx, &multiple); err != nil {
 				return nil, err
 			}
-			encoded, err := json.Marshal(multiple)
+			encoded, err := json.Marshal(multiple.Response)
 			if err != nil {
 				return nil, err
 			}
@@ -84,7 +84,7 @@ func registerTools(mcpServer *server.MCPServer, configResources *config.Resource
 			if err := configResources.TeamworkEngine.Do(ctx, &multiple); err != nil {
 				return nil, err
 			}
-			encoded, err := json.Marshal(multiple)
+			encoded, err := json.Marshal(multiple.Response)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/mcp/user/tools.go
+++ b/internal/mcp/user/tools.go
@@ -51,7 +51,7 @@ func registerTools(mcpServer *server.MCPServer, configResources *config.Resource
 			if err := configResources.TeamworkEngine.Do(ctx, &multiple); err != nil {
 				return nil, err
 			}
-			encoded, err := json.Marshal(multiple)
+			encoded, err := json.Marshal(multiple.Response)
 			if err != nil {
 				return nil, err
 			}
@@ -100,7 +100,7 @@ func registerTools(mcpServer *server.MCPServer, configResources *config.Resource
 			if err := configResources.TeamworkEngine.Do(ctx, &multiple); err != nil {
 				return nil, err
 			}
-			encoded, err := json.Marshal(multiple)
+			encoded, err := json.Marshal(multiple.Response)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
The encoded response sent back to the LLM container with the request information. This is not necessary since it's already part of the previous context.

## Related Issue

None.

## Checklist

- [x] I have read the [contributing guidelines](../blob/main/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../blob/main/SECURITY.md).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [cadastros@rafael.net.br](mailto:cadastros@rafael.net.br)) from the maintainers to push the changes.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

None.