### PR TITLE
fix: minimize the amount of data loaded from the workload

### DIFF
--- a/internal/mcp/user/tools.go
+++ b/internal/mcp/user/tools.go
@@ -287,7 +287,8 @@ func registerTools(mcpServer *server.MCPServer, configResources *config.Resource
 				"a more granular view of each person's capacity. An individual's capacity is based on their working hours, "+
 				"returned in the workload response, versus the total estimated time on their assigned tasks (minus any "+
 				"unavailable time assigned to them) in the selected time frame. A user is considered over capacity when "+
-				"their capacity exceeds their working hours."),
+				"their capacity exceeds their working hours. Missing dates in the response should be interpreted as the user "+
+				"not having any tasks assigned to them on that date and being available."),
 			mcp.WithString("start-date",
 				mcp.Required(),
 				mcp.Description("The start date of the workload period. The date must be in the format YYYY-MM-DD."),

--- a/internal/teamwork/workload/workload.go
+++ b/internal/teamwork/workload/workload.go
@@ -113,6 +113,11 @@ func (s Single) HTTPRequest(ctx context.Context, server string) (*http.Request, 
 	if len(s.Request.Filters.Include) > 0 {
 		query.Set("include", strings.Join(s.Request.Filters.Include, ","))
 	}
+
+	// to reduce the size of the response, we omit empty date entries where the
+	// user has no capacity and is not unavailable.
+	query.Set("omitEmptyDateEntries", "true")
+
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, nil


### PR DESCRIPTION
The workload can load a huge amount of data as it returns the user's daily capacity. This may exceed the LLM prompt limits and cause issues.

With the new `omitEmptyDateEntries` filter, only days with some capacity and unavailable days are returned; all others can be considered fully available.

## Related Issue

None.

## Checklist

- [x] I have read the [contributing guidelines](../blob/main/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../blob/main/SECURITY.md).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [cadastros@rafael.net.br](mailto:cadastros@rafael.net.br)) from the maintainers to push the changes.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

None.